### PR TITLE
Bugfix for header

### DIFF
--- a/src/komponenter/footer/footer-regular/footer-topp/footer-arbeidsflatevalg/FooterArbeidsflatevalg.tsx
+++ b/src/komponenter/footer/footer-regular/footer-topp/footer-arbeidsflatevalg/FooterArbeidsflatevalg.tsx
@@ -45,10 +45,7 @@ const FooterArbeidsflatevalg = () => {
         setLenker(getLenker());
     }, [arbeidsflate]);
 
-    const showContextMenu =
-        (language === Language.IKKEBESTEMT &&
-            COOKIES.LANGUAGE === Language.NORSK) ||
-        language === Language.NORSK;
+    const showContextMenu = language === Language.NORSK;
 
     return (
         <>

--- a/src/komponenter/header/header-regular/HeaderRegular.tsx
+++ b/src/komponenter/header/header-regular/HeaderRegular.tsx
@@ -7,13 +7,9 @@ import Arbeidsflatemeny from './arbeidsflatemeny/Arbeidsflatemeny';
 import DesktopMenylinje from './meny/DesktopMenylinje';
 
 export const RegularHeader = () => {
-    const { COOKIES } = useSelector((state: AppState) => state.environment);
     const language = useSelector((state: AppState) => state.language.language);
 
-    const showContextMenu =
-        (language === Language.IKKEBESTEMT &&
-            COOKIES.LANGUAGE === Language.NORSK) ||
-        language === Language.NORSK;
+    const showContextMenu = language === Language.NORSK;
 
     return (
         <Fragment>

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,9 +1,10 @@
 import { Request } from 'express';
 import { EnvironmentState } from '../store/reducers/environment-duck';
 import { MenuValue } from '../utils/meny-storage-utils';
+import { Language } from '../store/reducers/language-duck';
 
 interface Cookies {
-    [key: string]: MenuValue & string;
+    [key: string]: string;
 }
 
 interface Props {
@@ -34,8 +35,8 @@ export const clientEnv = ({ req, cookies }: Props): EnvironmentState => ({
     }),
     ...(cookies && {
         COOKIES: {
-            CONTEXT: cookies['decorator-context'],
-            LANGUAGE: cookies['decorator-language'],
+            CONTEXT: cookies['decorator-context'] as MenuValue,
+            LANGUAGE: cookies['decorator-language'] as Language,
         },
     }),
 });


### PR DESCRIPTION
Context-menyen og desktop menylinja får under visse omstendigheter samme attributes på sine <nav> elementer. Å fjerne bruk av cookies til å sette flagget for context-menyen ser ut til å fikse det, uten at jeg er helt sikker på hvorfor. Mulig at server-side og client-side state kommer ut av sync, og dette forårsaker bugs?