### PR TITLE
Fiks varsler-styling bug for XP

### DIFF
--- a/src/komponenter/header/header-regular/meny/varsel/Varselbjelle.less
+++ b/src/komponenter/header/header-regular/meny/varsel/Varselbjelle.less
@@ -7,7 +7,7 @@
     display: flex;
     align-items: center;
 
-    .toggle-varsler-container {
+    .varsler-toggle-container {
         display: inline-block;
         border: 1px solid transparent;
         vertical-align: middle;
@@ -87,7 +87,7 @@
             animation: dytt-ut 0.6s;
         }
 
-        .toggle-varsler {
+        .varsler-toggle {
             background: url('../../../../../ikoner/varsler/alarm.svg') no-repeat
                 center;
             background-size: 1.5rem 1.5rem;
@@ -110,7 +110,7 @@
             }
         }
 
-        &.har-nye-varsler .toggle-varsler {
+        &.har-nye-varsler .varsler-toggle {
             background-image: url('../../../../../ikoner/varsler/alarm-nytt-varsel.svg');
 
             &:hover {
@@ -126,12 +126,12 @@
     @media (min-width: @tabletLimitWidth) {
         width: 31px;
 
-        .toggle-varsler-container {
+        .varsler-toggle-container {
             display: inline-block;
             height: 1.9375rem;
             width: 1.9375rem;
 
-            .toggle-varsler {
+            .varsler-toggle {
                 width: 100%;
                 height: 100%;
                 border: none;

--- a/src/komponenter/header/header-regular/meny/varsel/Varselbjelle.tsx
+++ b/src/komponenter/header/header-regular/meny/varsel/Varselbjelle.tsx
@@ -53,8 +53,8 @@ const Varselbjelle = (props: VarselbjelleProps) => {
 
     const classname =
         antallUlesteVarsler > 0
-            ? 'toggle-varsler-container har-nye-varsler'
-            : 'toggle-varsler-container';
+            ? 'varsler-toggle-container har-nye-varsler'
+            : 'varsler-toggle-container';
 
     const ApneVarselEvent = () => {
         triggerGaEvent({
@@ -104,12 +104,12 @@ const Varselbjelle = (props: VarselbjelleProps) => {
                         clsName={classname}
                     />
                     <div className="media-tablet-desktop">
-                        <div id="toggle-varsler-container">
+                        <div id="varsler-toggle-container">
                             <MenylinjeKnapp
                                 toggleMenu={ApneVarselEvent}
                                 isOpen={clicked}
                                 classname={classname}
-                                id={'toggle-varsler-knapp-id'}
+                                id={'varsler-toggle-knapp-id'}
                                 ariaLabel={`Varsler. Du har ${
                                     antallVarsler > 0 ? antallVarsler : 'ingen'
                                 } varsler.`}

--- a/src/komponenter/header/header-regular/meny/varsel/varselknapp/VarselKnappMobil.tsx
+++ b/src/komponenter/header/header-regular/meny/varsel/varselknapp/VarselKnappMobil.tsx
@@ -26,14 +26,14 @@ const VarselKnappMobil = (props: Props) => {
     } = props;
     return (
         <div className="media-sm-mobil mobil-meny">
-            <div id="toggle-varsler-container" className={clsName}>
+            <div id="varsler-toggle-container" className={clsName}>
                 <Flatknapp
                     onClick={triggerVarsel}
                     className="varselknapp-mobil"
                     tabIndex={tabIndex ? 0 : -1}
                 >
                     <div
-                        className="toggle-varsler"
+                        className="varsler-toggle"
                         title="Varsler"
                         aria-label={`Varsler. Du har ${
                             antallVarsel > 0 ? antallVarsel : 'ingen'


### PR DESCRIPTION
- XP har klasser som overstyrer dekoratøren.
- Midlertidig fiks er å endre klassenavn