### PR TITLE
Fix for media-query mobil-bredde variabel

### DIFF
--- a/src/styling-variabler.less
+++ b/src/styling-variabler.less
@@ -7,7 +7,7 @@
 //width breakpoints
 @desktopMaxWidth: 1440px;
 @desktopMinWidth: 768px;
-@mobilMaxWidth: 767.9px;
+@mobilMaxWidth: 767.99px;
 
 @smallDesktopLimitWidth: 1024px;
 @smallDesktopLimitHeight: 900px;

--- a/src/styling-variabler.less
+++ b/src/styling-variabler.less
@@ -7,7 +7,7 @@
 //width breakpoints
 @desktopMaxWidth: 1440px;
 @desktopMinWidth: 768px;
-@mobilMaxWidth: calc(@desktopMinWidth - 1px);
+@mobilMaxWidth: 767.9px;
 
 @smallDesktopLimitWidth: 1024px;
 @smallDesktopLimitHeight: 900px;


### PR DESCRIPTION
- Fjerner bruk av calc i media-query variabel for mobil-bredde, ettersom IE11 og Edge <= 18 ikke støtter denne
- Øker presisjonen på variablen for å hindre mulig bug ved skjerm-skalering