### PR TITLE
Mobil header fix

### DIFF
--- a/src/komponenter/header/header-regular/HeaderRegular.tsx
+++ b/src/komponenter/header/header-regular/HeaderRegular.tsx
@@ -27,7 +27,7 @@ export const HeaderRegular = () => {
             <Skiplinks />
             <div className="header-z-wrapper">
                 {language === Language.NORSK && <Arbeidsflatemeny />}
-                <Sticky>
+                <Sticky mobilFixed={mobilMenyIsOpen}>
                     <HeaderMenylinje />
                 </Sticky>
             </div>

--- a/src/komponenter/header/header-regular/common/sticky/Sticky.tsx
+++ b/src/komponenter/header/header-regular/common/sticky/Sticky.tsx
@@ -6,10 +6,11 @@ import { getLinkAnchorId } from 'komponenter/header/header-regular/common/sticky
 import './Sticky.less';
 
 type Props = {
+    mobilFixed?: boolean;
     children: JSX.Element;
 };
 
-export const Sticky = ({ children }: Props) => {
+export const Sticky = ({ mobilFixed, children }: Props) => {
     const prevScrollOffset = useRef(0);
     const baseOffset = useRef(0);
 
@@ -75,7 +76,12 @@ export const Sticky = ({ children }: Props) => {
 
     return (
         <div className={'sticky-placeholder'} ref={placeholderRef}>
-            <div className={`sticky-container`} ref={stickyRef}>
+            <div
+                className={`sticky-container ${
+                    mobilFixed ? 'sticky-container--mobil-fixed' : ''
+                }`}
+                ref={stickyRef}
+            >
                 {children}
             </div>
         </div>


### PR DESCRIPTION
Fikser sticky-header når en klikker på mobilmenyen ved halvveis inn-scrollet menylinje