### PR TITLE
Bugfix på hovedmeny desktop

### DIFF
--- a/src/komponenter/header/Header.tsx
+++ b/src/komponenter/header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchMenypunkter } from 'store/reducers/menu-duck';
 import { MenuValue } from 'utils/meny-storage-utils';

--- a/src/komponenter/header/header-regular/desktop/hovedmeny/topp-seksjon/Toppseksjon.less
+++ b/src/komponenter/header/header-regular/desktop/hovedmeny/topp-seksjon/Toppseksjon.less
@@ -8,6 +8,10 @@
         margin: 0 -@margins-sides-desktop 1.5rem -@margins-sides-desktop;
         padding: 0 @margins-sides-desktop;
 
+        &-tittel-decoration {
+            display: none;
+        }
+
         @media (max-height: @smallDesktopLimitHeight),
             (max-width: @smallDesktopLimitWidth) {
             flex-direction: row;
@@ -15,6 +19,7 @@
             margin-bottom: 0.75rem;
 
             &-tittel-decoration {
+                display: inline;
                 .typo-normal;
                 font-weight: bold;
                 margin: 0 0.5rem;


### PR DESCRIPTION
Skjuler 'dekorasjonen' mellom tittel og forsidelenke i hovedmeny på desktop, ved visning i full skjermstørrelse.