### PR TITLE
Fikser wrapping av header-elementer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.22.21-prod",
+    "version": "1.22.24-test",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.22.21-prod",
+    "version": "1.22.24-test",
     "private": true,
     "scripts": {
         "start": "npm-run-all -p -r build-client-and-watch build-server-and-watch start-server-and-watch",

--- a/src/komponenter/header/header-regular/HeaderMenylinje.less
+++ b/src/komponenter/header/header-regular/HeaderMenylinje.less
@@ -13,7 +13,7 @@
     &__elementer {
         position: relative;
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         justify-content: space-between;
         align-items: center;
         width: 100%;
@@ -26,7 +26,8 @@
     }
 
     @media (max-width: @smallMobileMaxWidth) {
-        .hovedmeny__knapp-tekst {
+        .hovedmeny__knapp-tekst,
+        .varselbjelle__knapp-tekst {
             display: none;
         }
     }

--- a/src/komponenter/header/header-regular/common/varsler/varsler-knapp/VarslerKnapp.less
+++ b/src/komponenter/header/header-regular/common/varsler/varsler-knapp/VarslerKnapp.less
@@ -1,11 +1,9 @@
 @import (reference) '../../../../../../styling-variabler.less';
 
 .varselbjelle {
-    @media (min-width: @desktopMinWidth) {
-        &__knapp-tekst {
-            .typo-normal;
-            font-weight: bold;
-            margin-left: 0.25rem;
-        }
+    &__knapp-tekst {
+        .typo-normal;
+        font-weight: bold;
+        margin-left: 0.25rem;
     }
 }

--- a/src/komponenter/header/header-regular/mobil/MobilHeader.less
+++ b/src/komponenter/header/header-regular/mobil/MobilHeader.less
@@ -17,10 +17,10 @@
     .login-knapp-container,
     .varselbjelle__knapp {
         margin-right: 0.5rem;
+        margin-left: 0;
 
         @media (max-width: @smallMobileMaxWidth) {
-            margin-left: 0.2rem;
-            margin-right: 0.3rem;
+            margin-right: 0.25rem;
         }
     }
 


### PR DESCRIPTION
- Hindrer header-elementene fra å wrappe
- Skjuler varsel-tekst på smale skjermer
- Setter font på mobil-varsler lik som på desktop (noe mindre)