### PR TITLE
Q2 fiks for innloggingslinke-api

### DIFF
--- a/.nais/dev-sbs/q2.yaml
+++ b/.nais/dev-sbs/q2.yaml
@@ -37,7 +37,7 @@ spec:
         - name: API_VARSELINNBOKS_URL
           value: https://www-q2.nav.no/person/varselinnboks
         - name: API_INNLOGGINGSLINJE_URL
-          value: https://www-q2.nav.no/innloggingslinje-api/auth
+          value: https://www-q2.nav.no/fake-innloggingslinje-api/auth
         - name: API_UNLEASH_PROXY_URL
           value: https://www-q2.nav.no/person/pb-unleash-proxy
         - name: MINSIDE_ARBEIDSGIVER_URL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.25.23-prod",
+    "version": "1.25.24-test",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.25.23-prod",
+    "version": "1.25.24-test",
     "private": true,
     "scripts": {
         "start": "npm-run-all -p -r build-client-and-watch build-server-and-watch start-server-and-watch typecheck-watch",


### PR DESCRIPTION
Kall innloggingslinje-api i q2 med et fake endepunkt for å forhindre at open-am sletter token