### PR TITLE
logger sidetittel for statistikk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.25.34-prod",
+    "version": "1.25.35-test",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.25.34-prod",
+    "version": "1.25.35-test",
     "private": true,
     "scripts": {
         "start": "npm-run-all -p -r build-client-and-watch build-server-and-watch start-server-and-watch typecheck-watch",

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -12,7 +12,9 @@ export const initAmplitude = () => {
             includeReferrer: true,
             platform: window.location.toString(),
         });
-        logAmplitudeEvent('sidevisning');
+        logAmplitudeEvent('sidevisning', {
+            sidetittel: document.title,
+        });
     }
 };
 


### PR DESCRIPTION
Lagt til sidetittel  når vi logger sidevisning, for å kunne skille mellom 404-feil "Fant ikke siden" og vanlige sidevisninger
