### PR TITLE
Varselinnboks har fått ny URL for i Q1

### DIFF
--- a/.nais/dev-gcp/personbruker.yaml
+++ b/.nais/dev-gcp/personbruker.yaml
@@ -36,7 +36,7 @@ spec:
         - name: API_XP_SERVICES_URL
           value: https://www-q1.nav.no/_/service
         - name: API_VARSELINNBOKS_URL
-          value: https://www-q1.nav.no/person/varselinnboks
+          value: https://www.dev.nav.no/person/varselinnboks
         - name: API_INNLOGGINGSLINJE_URL
           value: https://innloggingsstatus.dev.nav.no/person/innloggingsstatus
         - name: API_UNLEASH_PROXY_URL

--- a/.nais/dev-sbs/q1.yaml
+++ b/.nais/dev-sbs/q1.yaml
@@ -35,7 +35,7 @@ spec:
         - name: API_XP_SERVICES_URL
           value: https://www-q1.nav.no/_/service
         - name: API_VARSELINNBOKS_URL
-          value: https://www-q1.nav.no/person/varselinnboks
+          value: https://www.dev.nav.no/person/varselinnboks
         - name: API_INNLOGGINGSLINJE_URL
           value: https://innloggingsstatus.dev.nav.no/person/innloggingsstatus
         - name: API_UNLEASH_PROXY_URL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.28.16-prod",
+    "version": "1.28.26-test",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.28.16-prod",
+    "version": "1.28.26-test",
     "private": true,
     "scripts": {
         "start": "npm-run-all -p -r build-client-and-watch build-server-and-watch start-server-and-watch typecheck-watch",


### PR DESCRIPTION
Varselinnboks-instansene som tidligere lå i namespace-et q1 er nå flyttet til namespace-et personbruker, men appen peker fortsatt bakover mot q1 for andre apper.

PB-592 - Gå gjennom namespace-endringer (personbruker vs Q1)