### PR TITLE
logging tilbakemelding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.29.29-prod",
+    "version": "1.29.38-test",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.29.29-prod",
+    "version": "1.29.38-test",
     "private": true,
     "scripts": {
         "start": "npm-run-all -p -r build-and-watch start-server-and-watch typecheck-watch",

--- a/src/komponenter/footer/feedback/Feedback.tsx
+++ b/src/komponenter/footer/feedback/Feedback.tsx
@@ -15,12 +15,12 @@ const Feedback = () => {
 
     const handleNei = () => {
         setState('nei');
-        logAmplitudeEvent('tilbakemelding', { svar: 'nei' });
+        logAmplitudeEvent('tilbakemelding', { kilde: 'footer', svar: 'nei' });
     };
 
     const handleJa = () => {
         setState('ja');
-        logAmplitudeEvent('tilbakemelding', { svar: 'ja' });
+        logAmplitudeEvent('tilbakemelding', { kilde: 'footer', svar: 'ja' });
     };
 
     return (

--- a/src/komponenter/footer/feedback/feedback-questions/AlternativJa.tsx
+++ b/src/komponenter/footer/feedback/feedback-questions/AlternativJa.tsx
@@ -35,7 +35,7 @@ const AlternativJa = (props: QuestionProps) => {
             dispatchFritekstFeil({ type: 'reset' });
             const feedback = createFeedbackRespons(feedbackMessage, language, 'Yes');
             lagreTilbakemelding(feedback, environment.FEEDBACK_API_URL)(reduxDispatch);
-            logAmplitudeEvent('tilbakemelding', { fritekst: 'besvart' });
+            logAmplitudeEvent('tilbakemelding', { kilde: 'footer', fritekst: 'besvart' });
             props.settBesvart();
         }
     };

--- a/src/komponenter/footer/feedback/feedback-questions/AlternativNei.tsx
+++ b/src/komponenter/footer/feedback/feedback-questions/AlternativNei.tsx
@@ -38,7 +38,7 @@ const AlternativNei = (props: QuestionProps) => {
             dispatchFritekstFeil({ type: 'reset' });
             const feedback = createFeedbackRespons(feedbackMessage, language, 'No');
             lagreTilbakemelding(feedback, environment.FEEDBACK_API_URL)(reduxDispatch);
-            logAmplitudeEvent('tilbakemelding', { fritekst: 'besvart' });
+            logAmplitudeEvent('tilbakemelding', { kilde: 'footer', fritekst: 'besvart' });
             props.settBesvart();
         }
     };

--- a/src/komponenter/footer/feedback/feedback-questions/KnappeRekke.tsx
+++ b/src/komponenter/footer/feedback/feedback-questions/KnappeRekke.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const KnappeRekke = ({ avbryt }: Props) => {
     const userClosedFeedback = () => {
-        logAmplitudeEvent('tilbakemelding', { fritekst: 'ingen kommentar' });
+        logAmplitudeEvent('tilbakemelding', { kilde: 'footer', fritekst: 'ingen kommentar' });
         avbryt();
     };
 


### PR DESCRIPTION
legger på 'kilde: footer' på amplitude logginger fra tilbakemeldingskomponent, så det ikke forveksles med logging fra Frida