### PR TITLE
Gjør input-felt for søk uncontrolled

### DIFF
--- a/src/komponenter/header/header-regular/common/sok/Sok.tsx
+++ b/src/komponenter/header/header-regular/common/sok/Sok.tsx
@@ -14,7 +14,7 @@ import { Environment } from 'store/reducers/environment-duck';
 import './Sok.less';
 
 interface Props {
-    id?: string;
+    id: string;
     isOpen: boolean;
     dropdownTransitionMs?: number;
     numResultsCallback?: (numResults: number) => void;

--- a/src/komponenter/header/header-regular/common/sok/sok-innhold/SokInput.tsx
+++ b/src/komponenter/header/header-regular/common/sok/sok-innhold/SokInput.tsx
@@ -13,12 +13,13 @@ type Props = {
     writtenInput: string;
     onChange: (value: string) => void;
     onReset: () => void;
-    id?: string;
+    id: string;
 };
 
 export const SokInput = (props: Props) => {
     const { onChange, onReset } = props;
     const { language, writtenInput, className, id } = props;
+
     return (
         <>
             <div className={'sok-input__tittel'}>
@@ -31,12 +32,21 @@ export const SokInput = (props: Props) => {
                     id={id}
                     onChange={(e) => onChange(e.target.value)}
                     className={className}
-                    value={writtenInput || ''}
                     placeholder={finnTekst('sok-input-placeholder', language)}
                     aria-label={finnTekst('sok-input-placeholder', language)}
                     type="search"
                 />
-                <SokKnapper writtenInput={writtenInput} onReset={onReset} id={id} />
+                <SokKnapper
+                    writtenInput={writtenInput}
+                    onReset={() => {
+                        onReset();
+                        const inputElement = document.getElementById(id) as HTMLInputElement;
+                        if (inputElement) {
+                            inputElement.value = '';
+                        }
+                    }}
+                    id={id}
+                />
             </div>
         </>
     );


### PR DESCRIPTION
Hindrer warnings ved enkelte implementasjoner ("value prop to a form field without an onChange handler"). Skal uansett ikke være nødvendig å ha denne input'en som controlled.