### PR TITLE
Moderate events

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,11 +1,8 @@
-import ReactGA from 'react-ga';
 import TagManager from 'react-gtm-module';
 import { MenuValue } from './meny-storage-utils';
 import { initAmplitude } from 'utils/amplitude';
 import { logAmplitudeEvent } from 'utils/amplitude';
 import { Params } from 'store/reducers/environment-duck';
-
-const trackingId = 'UA-9127381-16';
 
 const tagManagerArgs = {
     gtmId: 'GTM-PM9RP3',
@@ -28,10 +25,6 @@ export type AnalyticsEventArgs = {
 export const initAnalytics = (params: Params) => {
     TagManager.initialize(tagManagerArgs);
     initAmplitude(params);
-    ReactGA.initialize(trackingId, {
-        titleCase: false,
-        debug: false,
-    });
 };
 
 export const analyticsEvent = (props: AnalyticsEventArgs) => {
@@ -44,9 +37,11 @@ export const analyticsEvent = (props: AnalyticsEventArgs) => {
         kategori: category,
     });
 
-    ReactGA.event({
-        category: category,
-        action: actionFinal.toLowerCase(),
-        label: label || undefined,
+    TagManager.dataLayer({
+        dataLayer: {
+            event: category,
+            action: actionFinal.toLowerCase(),
+            data: label || undefined,
+        },
     });
 };


### PR DESCRIPTION
As discussed, this change intends to leverage GTM to moderate events sent to Google Analytics and remove duplicate initialization and decouples GA.