### PR TITLE
Sticky focus fix mk3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.30.9-prod",
+    "version": "1.30.10-test",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nav-dekoratoren",
-    "version": "1.30.9-prod",
+    "version": "1.30.10-test",
     "private": true,
     "scripts": {
         "start": "npm-run-all -p -r build-and-watch start-server-and-watch typecheck-watch",

--- a/src/komponenter/header/header-regular/common/sticky/StickyUtils.ts
+++ b/src/komponenter/header/header-regular/common/sticky/StickyUtils.ts
@@ -96,7 +96,7 @@ export const deferStickyOnAnchorLinkHandler = (
 };
 
 // If the element that will get focus may get overlapped by the sticky header, alter
-// the scroll-position to prevent this from happening
+// the header-position to prevent this from happening
 export const focusOverlapHandler = (stickyElement: HTMLElement) => (e: FocusEvent) => {
     // @ts-ignore (e.path is legacy/non-standard)
     const eventPath = e.composedPath?.() || e.path;

--- a/src/komponenter/header/header-regular/common/sticky/StickyUtils.ts
+++ b/src/komponenter/header/header-regular/common/sticky/StickyUtils.ts
@@ -98,6 +98,15 @@ export const deferStickyOnAnchorLinkHandler = (
 // If the element that will get focus may get overlapped by the sticky header, alter
 // the scroll-position to prevent this from happening
 export const focusOverlapHandler = (stickyElement: HTMLElement) => (e: FocusEvent) => {
+    // @ts-ignore (e.path is legacy/non-standard)
+    const eventPath = e.composedPath?.() || e.path;
+
+    // Skip this handler for elements focused inside the header, as the header can't overlap itself
+    // (Also skip for browsers without composedPath/path support)
+    if (!eventPath?.some || eventPath.some((path) => (path as HTMLElement)?.className?.includes('header-z-wrapper'))) {
+        return;
+    }
+
     const headerHeight = stickyElement?.getBoundingClientRect().height;
     const targetPos = (e.target as HTMLElement)?.getBoundingClientRect().top;
 


### PR DESCRIPTION
Hindrer sticky-headeren fra å "forsvinne" i enkelte tilfeller når et element i headeren får focus