### PR TITLE
Endrer deploy workflow triggere

### DIFF
--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -1,8 +1,7 @@
 name: Deploy-to-dev
 on:
-  push:
-    tags:
-      - "v*-test"
+  workflow_dispatch
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -1,10 +1,8 @@
 name: Deploy-to-prod
 on:
-  push:
-    tags:
-      - "v*-prod"
-      - "!v*-test"
-      - "!v*-dev"
+  release:
+    types: [released]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Abort if branch is not master
+        if: github.event.release.target_commitish != 'master'
+        run: echo "Release is not on master, aborting"; exit 1;
       - name: Define build environment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.q0.yml
+++ b/.github/workflows/deploy.q0.yml
@@ -1,10 +1,9 @@
 name: Deploy-to-q0
 on:
-  push:
-    tags:
-      - "v*-prod"
-      - "!v*-test"
-      - "!v*-dev"
+  workflow_dispatch
+  release:
+    types: [released]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.q0.yml
+++ b/.github/workflows/deploy.q0.yml
@@ -1,6 +1,6 @@
 name: Deploy-to-q0
 on:
-  workflow_dispatch
+  workflow_dispatch:
   release:
     types: [released]
 

--- a/.github/workflows/deploy.q1.yml
+++ b/.github/workflows/deploy.q1.yml
@@ -1,8 +1,9 @@
 name: Deploy-to-q1
 on:
-  push:
-    tags:
-      - "v*-test"
+  workflow_dispatch
+  release:
+    types: [released]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.q1.yml
+++ b/.github/workflows/deploy.q1.yml
@@ -1,6 +1,6 @@
 name: Deploy-to-q1
 on:
-  workflow_dispatch
+  workflow_dispatch:
   release:
     types: [released]
 

--- a/.github/workflows/deploy.q2.yml
+++ b/.github/workflows/deploy.q2.yml
@@ -1,6 +1,6 @@
 name: Deploy-to-q2
 on:
-  workflow_dispatch
+  workflow_dispatch:
   release:
     types: [released]
 

--- a/.github/workflows/deploy.q2.yml
+++ b/.github/workflows/deploy.q2.yml
@@ -1,8 +1,9 @@
 name: Deploy-to-q2
 on:
-  push:
-    tags:
-      - "v*-test"
+  workflow_dispatch
+  release:
+    types: [released]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.q6.yml
+++ b/.github/workflows/deploy.q6.yml
@@ -1,6 +1,6 @@
 name: Deploy-to-q6
 on:
-  workflow_dispatch
+  workflow_dispatch:
   release:
     types: [released]
 

--- a/.github/workflows/deploy.q6.yml
+++ b/.github/workflows/deploy.q6.yml
@@ -1,9 +1,9 @@
 name: Deploy-to-q6
 on:
-  push:
-    tags:
-      - "v*-test"
-      - "v*-dev"
+  workflow_dispatch
+  release:
+    types: [released]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Nav-dekoratoren ![nav.no logo](src/ikoner/meny/NavLogoRod.svg)
 
-![Deploy til prod](https://github.com/navikt/nav-dekoratoren/workflows/Deploy-to-prod/badge.svg) | ![Deploy til dev](https://github.com/navikt/nav-dekoratoren/workflows/Deploy-to-dev/badge.svg) <br />
-![Deploy til q0](https://github.com/navikt/nav-dekoratoren/workflows/Deploy-to-q0/badge.svg)
-![Deploy til q1](https://github.com/navikt/nav-dekoratoren/workflows/Deploy-to-q1/badge.svg)
-![Deploy til q6](https://github.com/navikt/nav-dekoratoren/workflows/Deploy-to-q6/badge.svg)
+![Deploy til prod](https://github.com/navikt/nav-dekoratoren/workflows/Deploy-to-prod/badge.svg) | ![Deploy til dev](https://github.com/navikt/nav-dekoratoren/workflows/Deploy-to-dev/badge.svg)
 
 Node.js Express applikasjon med frontend-komponenter i React.<br>
 Appen kjører på NAIS i en docker-container.
@@ -130,22 +127,22 @@ Bruk pus-decorator, les [readme](https://github.com/navikt/pus-decorator).
 
 Dekoratøren kan tilpasses med følgende [URL-parametere / query-string](https://en.wikipedia.org/wiki/Query_string). <br>
 
-| Parameter          | Type                                                  | Default              | Forklaring                                                                     |
-| ------------------ | ----------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------ |
-| context            | privatperson \ arbeidsgiver \ samarbeidspartner       | privatperson         | Setter menyen til definert kontekst                                            |
-| simple             | boolean                                               | false                | Viser en forenklet header og footer                                            |
-| enforceLogin       | boolean                                               | false                | Sørger for at brukeren er innlogget på definert sikkerhetsnivå (level) [1]     |
-| redirectToApp      | boolean                                               | false <br>(ditt-nav) | Sender brukeren tilbake til nåværende url etter innlogging via dekoratøren [2] |
-| level              | Level3 \| Level4                                      | Level3               | Gir brukeren innloggingsvalg basert på definert sikkerhetsnivå [2]             |
-| language           | nb \| nn \| en \| se \| pl                            | nb                   | Setter språket til dekoratøren ved server side rendering [3]                   |
-| availableLanguages | [{ locale: nb \| nn \| en \| se \| pl, url: string }] | [ ]                  | Setter alternativene til språkvelgeren ved server side rendering [4]           |
-| breadcrumbs        | [{ title: string, url: string }]                      | [ ]                  | Setter brødsmulestien for server side rendering [5]                            |
-| utilsBackground    | white \| gray \| transparent                          | transparent          | Setter bakgrunnsfargen på containeren til brødsmulesti og språkvelger          |
-| feedback           | boolean                                               | false                | Skjuler eller viser tilbakemeldingskomponentet                                 |
-| chatbot            | boolean                                               | true                 | Skjuler eller viser Chatbot Frida [6]                                          |
-| urlLookupTable     | boolean                                               | true                 | Aktiverer eller deaktiverer url-lookup-table [7]                               |
-| shareScreen        | boolean                                               | true                 | Aktiverer eller deaktiverer skjerdelingskomponent                              |
-| utloggingsvarsel   | boolean                                               | false(prod)/true(dev)| Aktiverer eller deaktiverer Utloggingsvarsel for login-token (5min left)       |
+| Parameter          | Type                                                  | Default               | Forklaring                                                                     |
+| ------------------ | ----------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------ |
+| context            | privatperson \ arbeidsgiver \ samarbeidspartner       | privatperson          | Setter menyen til definert kontekst                                            |
+| simple             | boolean                                               | false                 | Viser en forenklet header og footer                                            |
+| enforceLogin       | boolean                                               | false                 | Sørger for at brukeren er innlogget på definert sikkerhetsnivå (level) [1]     |
+| redirectToApp      | boolean                                               | false <br>(ditt-nav)  | Sender brukeren tilbake til nåværende url etter innlogging via dekoratøren [2] |
+| level              | Level3 \| Level4                                      | Level3                | Gir brukeren innloggingsvalg basert på definert sikkerhetsnivå [2]             |
+| language           | nb \| nn \| en \| se \| pl                            | nb                    | Setter språket til dekoratøren ved server side rendering [3]                   |
+| availableLanguages | [{ locale: nb \| nn \| en \| se \| pl, url: string }] | [ ]                   | Setter alternativene til språkvelgeren ved server side rendering [4]           |
+| breadcrumbs        | [{ title: string, url: string }]                      | [ ]                   | Setter brødsmulestien for server side rendering [5]                            |
+| utilsBackground    | white \| gray \| transparent                          | transparent           | Setter bakgrunnsfargen på containeren til brødsmulesti og språkvelger          |
+| feedback           | boolean                                               | false                 | Skjuler eller viser tilbakemeldingskomponentet                                 |
+| chatbot            | boolean                                               | true                  | Skjuler eller viser Chatbot Frida [6]                                          |
+| urlLookupTable     | boolean                                               | true                  | Aktiverer eller deaktiverer url-lookup-table [7]                               |
+| shareScreen        | boolean                                               | true                  | Aktiverer eller deaktiverer skjerdelingskomponent                              |
+| utloggingsvarsel   | boolean                                               | false(prod)/true(dev) | Aktiverer eller deaktiverer Utloggingsvarsel for login-token (5min left)       |
 
 [1] Kombineres med **level**, **redirectToApp** og [EnforceLoginLoader](https://github.com/navikt/nav-dekoratoren-moduler#readme) ved behov. <br>
 [2] Gjelder både ved automatisk innlogging og ved klikk på innloggingsknappen. <br>
@@ -248,6 +245,16 @@ Starter en Node Express / dev - server på <br> http://localhost:8088/dekoratore
 npm run build-dev (for testing lokalt)
 npm run build (for produksjon)
 ```
+
+## Deploy til dev-miljø
+
+Start deploy workflow via Github web-UI: Actions -> Workflows -> Deploy-to-dev -> Run workflow
+
+## Prodsetting
+
+-   Lag en PR til master, og merge inn etter godkjenning
+-   Lag en release på master med versjon-bump, beskrivende tittel og oppsummering av endringene dine
+-   Publiser release'en for å starte deploy til prod
 
 ## Henvendelser
 


### PR DESCRIPTION
- Legger til workflow dispatch og/eller release trigger på alle deploy-workflows
  - Deployer til prod ved release
  - Deployer til dev ved workflow dispatch
  - Deployer til q-miljøer ved release og workflow dispatch. Tanken er at disse holdes i sync med prod-release, ettersom q-miljøene sjelden/aldri brukes til test av dekoratøren direkte. Beholder samtidig mulighet for separate deploys med workflow dispatch dersom det skulle være behov.
- Fjerner tag-baserte push-triggere