### PR TITLE
Fix timeout issue safari

### DIFF
--- a/src/komponenter/common/utloggingsvarsel/komponenter/UtloggingsvarselTekstInnhold.tsx
+++ b/src/komponenter/common/utloggingsvarsel/komponenter/UtloggingsvarselTekstInnhold.tsx
@@ -14,8 +14,7 @@ const UtloggingsvarselTekstInnhold: FunctionComponent<Props> = (props) => {
         <div className={cls.element('tekst-innhold')}>
             <Systemtittel className={cls.element('heading')}>{overskrift}</Systemtittel>
             <Normaltekst>
-                Lukk denne boksen og avslutt det du jobber med. <br />
-                Er du ferdig, kan du logge ut med en gang eller logge inn på ny.
+                Avslutt det du jobber med. Trenger du mer tid, må du logge inn på nytt.
             </Normaltekst>
         </div>
     );

--- a/src/komponenter/common/utloggingsvarsel/timestamp.utils.ts
+++ b/src/komponenter/common/utloggingsvarsel/timestamp.utils.ts
@@ -48,8 +48,8 @@ const timeout = (
     utloggingsvarsel: UtloggingsvarselState,
     setCookie: (name: string, value: any, options?: CookieSetOptions | undefined) => void
 ) => {
-    const SECONDS_BETWEEN_TIMEOUT = 9;
-    const remainingTimeoutDiff = timeoutDiff - SECONDS_BETWEEN_TIMEOUT;
+    const SECONDS_BETWEEN_SET_TIMEOUT = 9;
+    const remainingTimeoutDiff = timeoutDiff - SECONDS_BETWEEN_SET_TIMEOUT;
     setTimeout(() => {
         if (remainingTimeoutDiff < 0) {
             const utloggingsState: UtloggingsvarselState = {
@@ -72,7 +72,7 @@ const timeout = (
                 setCookie
             );
         }
-    }, SECONDS_BETWEEN_TIMEOUT * 1000);
+    }, SECONDS_BETWEEN_SET_TIMEOUT * 1000);
 };
 
 const setUtloggingVarsel = (

--- a/src/komponenter/common/utloggingsvarsel/timestamp.utils.ts
+++ b/src/komponenter/common/utloggingsvarsel/timestamp.utils.ts
@@ -48,17 +48,32 @@ const timeout = (
     utloggingsvarsel: UtloggingsvarselState,
     setCookie: (name: string, value: any, options?: CookieSetOptions | undefined) => void
 ) => {
+    const SECONDS_BETWEEN_TIMEOUT = 9;
+    const remainingTimeoutDiff = timeoutDiff - SECONDS_BETWEEN_TIMEOUT;
     setTimeout(() => {
-        const utloggingsState: UtloggingsvarselState = {
-            ...utloggingsvarsel,
-            varselState: VarselEkspandert.EKSPANDERT,
-            vistSistePaminnelse: false,
-            modalLukketAvBruker: false
-        };
-        dispatch(utloggingsvarselOppdatereStatus(utloggingsState));
-        setCookie(CookieName.DECORATOR_LOGOUT_WARNING, utloggingsState, cookieOptions);
-        setUtloggingVarsel(timestamp, setModalOpen, setUnixTimeStamp);
-    }, timeoutDiff * 1000);
+        if (remainingTimeoutDiff < 0) {
+            const utloggingsState: UtloggingsvarselState = {
+                ...utloggingsvarsel,
+                varselState: VarselEkspandert.EKSPANDERT,
+                vistSistePaminnelse: false,
+                modalLukketAvBruker: false,
+            };
+            dispatch(utloggingsvarselOppdatereStatus(utloggingsState));
+            setCookie(CookieName.DECORATOR_LOGOUT_WARNING, utloggingsState, cookieOptions);
+            setUtloggingVarsel(timestamp, setModalOpen, setUnixTimeStamp);
+        } else {
+            console.log('setting new timeout');
+            timeout(
+                timestamp,
+                remainingTimeoutDiff,
+                setModalOpen,
+                setUnixTimeStamp,
+                dispatch,
+                utloggingsvarsel,
+                setCookie
+            );
+        }
+    }, SECONDS_BETWEEN_TIMEOUT * 1000);
 };
 
 const setUtloggingVarsel = (

--- a/src/komponenter/common/utloggingsvarsel/timestamp.utils.ts
+++ b/src/komponenter/common/utloggingsvarsel/timestamp.utils.ts
@@ -30,8 +30,8 @@ export const checkTimeStampAndSetTimeStamp = (
         }
         return timeout(
             jwtTimestamp,
-            differanse - ANTALL_MIN_NAR_VARSELSTART
-            , setModalOpen,
+            differanse - ANTALL_MIN_NAR_VARSELSTART,
+            setModalOpen,
             setUnixTimeStamp,
             dispatch,
             utlogginsvarsel,
@@ -62,7 +62,6 @@ const timeout = (
             setCookie(CookieName.DECORATOR_LOGOUT_WARNING, utloggingsState, cookieOptions);
             setUtloggingVarsel(timestamp, setModalOpen, setUnixTimeStamp);
         } else {
-            console.log('setting new timeout');
             timeout(
                 timestamp,
                 remainingTimeoutDiff,


### PR DESCRIPTION
Safari på iOS terminerer alle scripts som kjører lenger enn 10 sekunder. Dermed må vi dele setTimeout inn i chunks helt til de totale 55 minuttene er "brukt opp".