### PR TITLE
Fikser proxy-feil i dev-miljø

### DIFF
--- a/.nais/dev-gcp/personbruker.yaml
+++ b/.nais/dev-gcp/personbruker.yaml
@@ -29,7 +29,6 @@ spec:
             external:
                 - host: www.dev.nav.no
                 - host: innloggingslinje-api.dev.nav.no
-                - host: www-q1.nav.no
     env:
         - name: ENV
           value: dev

--- a/src/komponenter/header/header-regular/common/varsler/varsler-knapp/VarslerKnapp.tsx
+++ b/src/komponenter/header/header-regular/common/varsler/varsler-knapp/VarslerKnapp.tsx
@@ -26,8 +26,7 @@ export const VarslerKnapp = () => {
     const { isOpen, varsler, appUrl, language } = useSelector(stateSelector);
 
     const toggleVarslerDropdown = () => {
-        if (!isOpen && varsler.nyesteVarsler.length > 0) {
-            // && varsler.totaltAntallUleste > 0
+        if (!isOpen && varsler.totaltAntallUleste > 0 && varsler.nyesteVarsler.length > 0) {
             settVarslerSomLest(appUrl, varsler.nyesteVarsler[0].id, dispatch);
         }
         analyticsEvent({

--- a/src/komponenter/header/header-regular/common/varsler/varsler-knapp/VarslerKnapp.tsx
+++ b/src/komponenter/header/header-regular/common/varsler/varsler-knapp/VarslerKnapp.tsx
@@ -26,7 +26,8 @@ export const VarslerKnapp = () => {
     const { isOpen, varsler, appUrl, language } = useSelector(stateSelector);
 
     const toggleVarslerDropdown = () => {
-        if (!isOpen && varsler.totaltAntallUleste > 0 && varsler.nyesteVarsler.length > 0) {
+        if (!isOpen && varsler.nyesteVarsler.length > 0) {
+            // && varsler.totaltAntallUleste > 0
             settVarslerSomLest(appUrl, varsler.nyesteVarsler[0].id, dispatch);
         }
         analyticsEvent({

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -41,6 +41,13 @@ const backupCache = new NodeCache({
     checkperiod: 0,
 });
 
+const setAllowedCorsProxyHeaders = (proxyRes: IncomingMessage, req: Request, res: Response) => {
+    const requestHeaders = req.headers['access-control-request-headers'];
+    if (requestHeaders) {
+        proxyRes.headers['access-control-allow-headers'] = req.headers['access-control-request-headers'];
+    }
+};
+
 // Middleware
 app.disable('x-powered-by');
 app.use(compression());
@@ -173,9 +180,7 @@ app.use(
         target: `${process.env.API_VARSELINNBOKS_URL}`,
         pathRewrite: { [`^${proxiedVarslerUrl}`]: '' },
         changeOrigin: true,
-        onProxyRes: (proxyRes: IncomingMessage, req: Request, res: Response) => {
-            proxyRes.headers['access-control-allow-headers'] = req.headers['access-control-request-headers'];
-        },
+        onProxyRes: setAllowedCorsProxyHeaders,
     })
 );
 
@@ -185,6 +190,7 @@ app.use(
         target: `${process.env.API_XP_SERVICES_URL}/navno.nav.no.search/search2/sok`,
         pathRewrite: { [`^${proxiedSokUrl}`]: '' },
         changeOrigin: true,
+        onProxyRes: setAllowedCorsProxyHeaders,
     })
 );
 
@@ -194,6 +200,7 @@ app.use(
         target: `${process.env.API_XP_SERVICES_URL}/no.nav.navno/driftsmeldinger`,
         pathRewrite: { [`^${proxiedDriftsmeldingerUrl}`]: '' },
         changeOrigin: true,
+        onProxyRes: setAllowedCorsProxyHeaders,
     })
 );
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,6 +11,7 @@ import { template } from './template';
 import compression from 'compression';
 import dotenv from 'dotenv';
 import mockMenu from './mock/menu.json';
+import { IncomingMessage } from 'http';
 
 require('console-stamp')(console, '[HH:MM:ss.l]');
 
@@ -33,11 +34,11 @@ const mainCacheKey = 'navno-menu';
 const backupCacheKey = 'navno-menu-backup';
 const mainCache = new NodeCache({
     stdTTL: tenSeconds,
-    checkperiod: oneMinuteInSeconds
+    checkperiod: oneMinuteInSeconds,
 });
 const backupCache = new NodeCache({
     stdTTL: 0,
-    checkperiod: 0
+    checkperiod: 0,
 });
 
 // Middleware
@@ -74,9 +75,9 @@ app.use(
             getLabelValues: (req: Request, res: Response) => ({
                 app: process.env.NAIS_APP_NAME || 'nav-dekoratoren',
                 namespace: process.env.NAIS_NAMESPACE || 'local',
-                cluster: process.env.NAIS_CLUSTER_NAME || 'local'
-            })
-        }
+                cluster: process.env.NAIS_CLUSTER_NAME || 'local',
+            }),
+        },
     })
 );
 
@@ -107,7 +108,7 @@ app.get(`${appBasePath}/api/meny`, (req, res) => {
     } else {
         // Fetch fom XP
         fetch(`${process.env.API_XP_SERVICES_URL}/no.nav.navno/menu`, {
-            method: 'GET'
+            method: 'GET',
         })
             .then((xpRes) => {
                 if (xpRes.ok && xpRes.status === 200) {
@@ -171,7 +172,10 @@ app.use(
     createProxyMiddleware(proxiedVarslerUrl, {
         target: `${process.env.API_VARSELINNBOKS_URL}`,
         pathRewrite: { [`^${proxiedVarslerUrl}`]: '' },
-        changeOrigin: true
+        changeOrigin: true,
+        onProxyRes: (proxyRes: IncomingMessage, req: Request, res: Response) => {
+            proxyRes.headers['access-control-allow-headers'] = req.headers['access-control-request-headers'];
+        },
     })
 );
 
@@ -180,7 +184,7 @@ app.use(
     createProxyMiddleware(proxiedSokUrl, {
         target: `${process.env.API_XP_SERVICES_URL}/navno.nav.no.search/search2/sok`,
         pathRewrite: { [`^${proxiedSokUrl}`]: '' },
-        changeOrigin: true
+        changeOrigin: true,
     })
 );
 
@@ -189,7 +193,7 @@ app.use(
     createProxyMiddleware(proxiedDriftsmeldingerUrl, {
         target: `${process.env.API_XP_SERVICES_URL}/no.nav.navno/driftsmeldinger`,
         pathRewrite: { [`^${proxiedDriftsmeldingerUrl}`]: '' },
-        changeOrigin: true
+        changeOrigin: true,
     })
 );
 
@@ -210,7 +214,7 @@ app.use(
                 res.header('Cache-Control', `max-age=${fiveMinutesInSeconds}`);
                 res.header('Pragma', `max-age=${fiveMinutesInSeconds}`);
             }
-        }
+        },
     })
 );
 
@@ -223,7 +227,7 @@ app.use((e: Error, req: Request, res: Response, next: NextFunction) => {
     console.error(e.stack);
     res.status(405);
     res.send({
-        error: { status: 405, message: e.message }
+        error: { status: 405, message: e.message },
     });
 });
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -189,7 +189,7 @@ app.use(
     createProxyMiddleware(proxiedSokUrl, {
         target: `${process.env.API_XP_SERVICES_URL}/navno.nav.no.search/search2/sok`,
         pathRewrite: { [`^${proxiedSokUrl}`]: '' },
-        changeOrigin: true,
+        // changeOrigin: true,
         onProxyRes: (proxyRes: IncomingMessage, req: Request, res: Response) => {
             console.log(`Sok proxy res: ${proxyRes.statusCode} - ${proxyRes.statusMessage}`);
 
@@ -203,7 +203,7 @@ app.use(
     createProxyMiddleware(proxiedDriftsmeldingerUrl, {
         target: `${process.env.API_XP_SERVICES_URL}/no.nav.navno/driftsmeldinger`,
         pathRewrite: { [`^${proxiedDriftsmeldingerUrl}`]: '' },
-        changeOrigin: true,
+        // changeOrigin: true,
         onProxyRes: setAllowedCorsProxyHeaders,
     })
 );

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -184,7 +184,7 @@ app.use(
     })
 );
 
-app.use(
+/*app.use(
     proxiedSokUrl,
     createProxyMiddleware(proxiedSokUrl, {
         target: `${process.env.API_XP_SERVICES_URL}/navno.nav.no.search/search2/sok`,
@@ -196,7 +196,23 @@ app.use(
             setAllowedCorsProxyHeaders(proxyRes, req, res);
         },
     })
-);
+);*/
+
+app.get(proxiedSokUrl, async (req, res) => {
+    const queryString = new URL(req.url, process.env.APP_BASE_URL).search;
+    const url = `${process.env.API_XP_SERVICES_URL}/navno.nav.no.search/search2/sok${queryString}`;
+
+    console.log(`Searching with url ${url}`);
+
+    const response = await fetch(url);
+
+    if (response.status === 200) {
+        const json = await response.json();
+        res.status(200).send(json);
+    }
+
+    return res.status(response.status).send(response.statusText);
+});
 
 app.use(
     proxiedDriftsmeldingerUrl,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -55,7 +55,7 @@ app.use((req, res, next) => {
         res.header('Access-Control-Allow-Origin', req.get('origin'));
         res.header('Access-Control-Allow-Methods', 'GET,HEAD,OPTIONS,POST,PUT');
         res.header('Access-Control-Allow-Credentials', 'true');
-        res.header('Access-Control-Allow-Headers', 'Origin,Content-Type,Accept,Authorization');
+        res.header('Access-Control-Allow-Headers', 'Origin,Content-Type,Accept,Authorization,Adrum');
     }
 
     // Cache control

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -44,7 +44,7 @@ const backupCache = new NodeCache({
 const setAllowedCorsProxyHeaders = (proxyRes: IncomingMessage, req: Request, res: Response) => {
     const requestHeaders = req.headers['access-control-request-headers'];
     if (requestHeaders) {
-        proxyRes.headers['access-control-allow-headers'] = req.headers['access-control-request-headers'];
+        proxyRes.headers['access-control-allow-headers'] = requestHeaders;
     }
 };
 
@@ -190,7 +190,11 @@ app.use(
         target: `${process.env.API_XP_SERVICES_URL}/navno.nav.no.search/search2/sok`,
         pathRewrite: { [`^${proxiedSokUrl}`]: '' },
         changeOrigin: true,
-        onProxyRes: setAllowedCorsProxyHeaders,
+        onProxyRes: (proxyRes: IncomingMessage, req: Request, res: Response) => {
+            console.log(`Sok proxy res: ${proxyRes.statusCode} - ${proxyRes.statusMessage}`);
+
+            setAllowedCorsProxyHeaders(proxyRes, req, res);
+        },
     })
 );
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -189,7 +189,7 @@ app.use(
     createProxyMiddleware(proxiedSokUrl, {
         target: `${process.env.API_XP_SERVICES_URL}/navno.nav.no.search/search2/sok`,
         pathRewrite: { [`^${proxiedSokUrl}`]: '' },
-        // changeOrigin: true,
+        changeOrigin: true,
         onProxyRes: (proxyRes: IncomingMessage, req: Request, res: Response) => {
             console.log(`Sok proxy res: ${proxyRes.statusCode} - ${proxyRes.statusMessage}`);
 
@@ -203,7 +203,7 @@ app.use(
     createProxyMiddleware(proxiedDriftsmeldingerUrl, {
         target: `${process.env.API_XP_SERVICES_URL}/no.nav.navno/driftsmeldinger`,
         pathRewrite: { [`^${proxiedDriftsmeldingerUrl}`]: '' },
-        // changeOrigin: true,
+        changeOrigin: true,
         onProxyRes: setAllowedCorsProxyHeaders,
     })
 );


### PR DESCRIPTION
- Fikser CORS-feil ved requests med Access-Control-Request-Headers ved å sette Access-Control-Allow-Headers tilsvarende. Ettersom vi kun tillater requests fra egne domener så bør dette være trygt.
- Fikser proxy mot Enonic-tjenester. "Noe" med http-proxy-middleware feiler ved request fra dev-gcp til dev Enonic. Fjerner bruk av http-proxy-middleware og tar i bruk egen implementasjon.