### PR TITLE
Hindrer redundante fetches fra XP når cachen expires

### DIFF
--- a/src/server/api-handlers/_cachedResourceHandler.ts
+++ b/src/server/api-handlers/_cachedResourceHandler.ts
@@ -4,6 +4,8 @@ import { tenSeconds } from '../utils';
 
 type RevalidateCacheFunc = (cache: NodeCache) => Promise<any>;
 
+// Returns a RequestHandler with a cached response. The cache is periodically revalidated
+// with the supplied function
 export const cachedResourceHandler = (revalidateCacheFunc: RevalidateCacheFunc, cacheKey: string): RequestHandler => {
     const cache = new NodeCache({
         stdTTL: tenSeconds,

--- a/src/server/api-handlers/_cachedResourceHandler.ts
+++ b/src/server/api-handlers/_cachedResourceHandler.ts
@@ -38,8 +38,8 @@ export const cachedResourceHandler = (revalidateCacheFunc: RevalidateCacheFunc, 
                 res.status(200).send(value);
             };
 
-            revalidateCache();
             cache.on('set', sendResponseOnCacheSet);
+            revalidateCache();
         }
     };
 };

--- a/src/server/api-handlers/_cachedResourceHandler.ts
+++ b/src/server/api-handlers/_cachedResourceHandler.ts
@@ -6,7 +6,7 @@ type RevalidateCacheFunc = (cache: NodeCache) => Promise<any>;
 
 // Returns a RequestHandler with a cached response. The cache is periodically revalidated
 // with the supplied function
-export const cachedResourceHandler = (revalidateCacheFunc: RevalidateCacheFunc, cacheKey: string): RequestHandler => {
+export const getCachedRequestHandler = (revalidateCacheFunc: RevalidateCacheFunc, cacheKey: string): RequestHandler => {
     const cache = new NodeCache({
         stdTTL: tenSeconds,
         deleteOnExpire: false,

--- a/src/server/api-handlers/_cachedResourceHandler.ts
+++ b/src/server/api-handlers/_cachedResourceHandler.ts
@@ -33,10 +33,8 @@ export const cachedResourceHandler = (revalidateCacheFunc: RevalidateCacheFunc, 
             res.status(200).send(cached);
         } else {
             const sendResponseOnCacheSet = (key: string, value: any) => {
-                if (key === cacheKey) {
-                    cache.off('set', sendResponseOnCacheSet);
-                    res.status(200).send(value);
-                }
+                cache.off('set', sendResponseOnCacheSet);
+                res.status(200).send(value);
             };
 
             revalidateCache();

--- a/src/server/api-handlers/_cachedResourceHandler.ts
+++ b/src/server/api-handlers/_cachedResourceHandler.ts
@@ -1,0 +1,46 @@
+import { RequestHandler } from 'express';
+import NodeCache from 'node-cache';
+import { tenSeconds } from '../utils';
+
+type RevalidateCacheFunc = (cache: NodeCache) => Promise<any>;
+
+export const cachedResourceHandler = (revalidateCacheFunc: RevalidateCacheFunc, cacheKey: string): RequestHandler => {
+    const cache = new NodeCache({
+        stdTTL: tenSeconds,
+        deleteOnExpire: false,
+    });
+
+    let isFetching = false;
+
+    const revalidateCache = () => {
+        if (isFetching) {
+            return;
+        }
+
+        isFetching = true;
+
+        revalidateCacheFunc(cache).finally(() => {
+            isFetching = false;
+        });
+    };
+
+    cache.on('expired', revalidateCache);
+
+    return (req, res) => {
+        const cached = cache.get(cacheKey);
+
+        if (cached) {
+            res.status(200).send(cached);
+        } else {
+            const sendResponseOnCacheSet = (key: string, value: any) => {
+                if (key === cacheKey) {
+                    cache.off('set', sendResponseOnCacheSet);
+                    res.status(200).send(value);
+                }
+            };
+
+            revalidateCache();
+            cache.on('set', sendResponseOnCacheSet);
+        }
+    };
+};

--- a/src/server/api-handlers/_cachedResourceHandler.ts
+++ b/src/server/api-handlers/_cachedResourceHandler.ts
@@ -34,6 +34,7 @@ export const cachedResourceHandler = (revalidateCacheFunc: RevalidateCacheFunc, 
         } else {
             const sendResponseOnCacheSet = (key: string, value: any) => {
                 cache.off('set', sendResponseOnCacheSet);
+                console.log(`Sending cache response on set event for ${cacheKey}`);
                 res.status(200).send(value);
             };
 

--- a/src/server/api-handlers/driftsmeldinger.ts
+++ b/src/server/api-handlers/driftsmeldinger.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import { RequestHandler } from 'express';
 import NodeCache from 'node-cache';
-import { cachedResourceHandler } from './_cachedResourceHandler';
+import { getCachedRequestHandler } from './_cachedResourceHandler';
 
 const driftsmeldingerServiceUrl = `${process.env.API_XP_SERVICES_URL}/no.nav.navno/driftsmeldinger`;
 
@@ -26,7 +26,7 @@ const revalidateDriftsmeldingerCache = (cache: NodeCache) =>
             cache.set(cacheKey, prevCache);
         });
 
-export const getDriftsmeldingerHandler: RequestHandler = cachedResourceHandler(
+export const getDriftsmeldingerHandler: RequestHandler = getCachedRequestHandler(
     revalidateDriftsmeldingerCache,
     cacheKey
 );

--- a/src/server/api-handlers/menu.ts
+++ b/src/server/api-handlers/menu.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import menuFallback from '../mock/menu.json';
 import { RequestHandler } from 'express';
 import NodeCache from 'node-cache';
-import { cachedResourceHandler } from './_cachedResourceHandler';
+import { getCachedRequestHandler } from './_cachedResourceHandler';
 
 const menuServiceUrl = `${process.env.API_XP_SERVICES_URL}/no.nav.navno/menu`;
 
@@ -32,4 +32,4 @@ const revalidateMenuCache = (cache: NodeCache) =>
             }
         });
 
-export const getMenuHandler: RequestHandler = cachedResourceHandler(revalidateMenuCache, cacheKey);
+export const getMenuHandler: RequestHandler = getCachedRequestHandler(revalidateMenuCache, cacheKey);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6,7 +6,7 @@ import cookiesMiddleware from 'universal-cookie-express';
 import { template } from './template';
 import compression from 'compression';
 import dotenv from 'dotenv';
-import { getMenyHandler } from './api-handlers/meny';
+import { getMenuHandler } from './api-handlers/menu';
 import { getSokHandler } from './api-handlers/sok';
 import { getDriftsmeldingerHandler } from './api-handlers/driftsmeldinger';
 import { varselInnboksProxyHandler, varselInnboksProxyUrl } from './api-handlers/varsler';
@@ -95,7 +95,7 @@ app.get(`${appBasePath}/env`, (req, res, next) => {
 });
 
 // Api endpoints
-app.get(`${appBasePath}/api/meny`, getMenyHandler);
+app.get(`${appBasePath}/api/meny`, getMenuHandler);
 app.get(`${appBasePath}/api/sok`, getSokHandler);
 app.get(`${appBasePath}/api/driftsmeldinger`, getDriftsmeldingerHandler);
 app.use(varselInnboksProxyUrl, varselInnboksProxyHandler);


### PR DESCRIPTION
- Hindrer flere samtidige fetch-kall til XP når cachen er expired. Samtlige kall til de aktuelle api'ene vil trigge 'expired'-eventet når kallet skjer etter at ttl'en er utløpt, og hvert kall kjører dermed funksjonen for cache-revalidering. Setter derfor et 'isFetching' flagg slik at det kun kjøres ett kall til XP for hver cache i hver revaliderings-periode.
- Refactor for kode-gjenbruk i cachede api'er