### PR TITLE
Fikser regex for validering av nav-url'er

### DIFF
--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -281,7 +281,7 @@ export const validateBreadcrumbs = (breadcrumbs: Breadcrumb[]) => {
 
 // Validator utils
 export const isNavUrl = (url: string) =>
-    /^(\/|(https?:\/\/localhost)|(https:\/\/([a-z0-9-]+[.])*nav[.]no)).*/i.test(url);
+    /^(\/|(https?:\/\/localhost)|(https:\/\/([a-z0-9-]+[.])*nav[.]no($|\/)))/i.test(url);
 
 // Deprecated map to support norsk | engelsk | samisk
 const mapToLocale = (language?: string) => {


### PR DESCRIPTION
Hindrer url'er av type https://nav.no.evil.url fra å valideres som korrekt.