### PR TITLE
Setter header for CORP på statiske filer + fjerner ds-css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
             "name": "nav-dekoratoren",
             "version": "1.32.15-test",
             "dependencies": {
-                "@navikt/ds-css": "^0.12.6",
                 "@navikt/fnrvalidator": "^1.1.3",
                 "@navikt/nav-chatbot": "^2.5.11",
                 "@navikt/nav-dekoratoren-moduler": "^1.6.6",
@@ -2569,11 +2568,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/@navikt/ds-css": {
-            "version": "0.12.6",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-0.12.6.tgz",
-            "integrity": "sha512-nf65d6LEpI8a9y1QB56/rXgotvJH8uCkTk93n5AoybUF53tuflXe2BhNXUYKqKnRhVSIiPz+/ZUYGEC7PZ4c/g=="
         },
         "node_modules/@navikt/fnrvalidator": {
             "version": "1.1.3",
@@ -26061,11 +26055,6 @@
                     }
                 }
             }
-        },
-        "@navikt/ds-css": {
-            "version": "0.12.6",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-0.12.6.tgz",
-            "integrity": "sha512-nf65d6LEpI8a9y1QB56/rXgotvJH8uCkTk93n5AoybUF53tuflXe2BhNXUYKqKnRhVSIiPz+/ZUYGEC7PZ4c/g=="
         },
         "@navikt/fnrvalidator": {
             "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "url": "https://github.com/navikt/nav-dekoratoren/issues"
     },
     "dependencies": {
-        "@navikt/ds-css": "^0.12.6",
         "@navikt/fnrvalidator": "^1.1.3",
         "@navikt/nav-chatbot": "^2.5.11",
         "@navikt/nav-dekoratoren-moduler": "^1.6.6",

--- a/src/index.less
+++ b/src/index.less
@@ -1,5 +1,8 @@
 @import './styling-variabler.less';
-@import '~@navikt/ds-css/dist/index.css';
+
+:root {
+    --navds-global-color-purple-500: rgba(99, 70, 137, 1);
+}
 
 body {
     overflow-y: scroll;

--- a/src/index.less
+++ b/src/index.less
@@ -1,9 +1,5 @@
 @import './styling-variabler.less';
 
-:root {
-    --navds-global-color-purple-500: rgba(99, 70, 137, 1);
-}
-
 body {
     overflow-y: scroll;
     overflow-x: hidden;

--- a/src/komponenter/footer/chatbot/ChatbotWrapper.less
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.less
@@ -1,0 +1,3 @@
+#nav-chatbot {
+    --navds-global-color-purple-500: rgba(99, 70, 137, 1);
+}

--- a/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
@@ -4,13 +4,12 @@ import { AppState } from 'store/reducers';
 import { verifyWindowObj } from 'utils/Environment';
 import { logAmplitudeEvent } from 'utils/amplitude';
 import { MenuValue } from '../../../utils/meny-storage-utils';
+import './ChatbotWrapper.less';
 
 // Prevents SSR crash
 const Chatbot = verifyWindowObj() ? require('@navikt/nav-chatbot') : () => null;
 
-const testUrlHosts = [
-    'dekoratoren.ekstern.dev.nav.no',
-];
+const testUrlHosts = ['dekoratoren.ekstern.dev.nav.no'];
 
 const stateSelector = (state: AppState) => ({
     isChatbotEnabled: state.environment.PARAMS.CHATBOT,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -43,6 +43,7 @@ app.use((req, res, next) => {
         res.header('Access-Control-Allow-Origin', req.get('origin'));
         res.header('Access-Control-Allow-Methods', 'GET,HEAD,OPTIONS,POST,PUT');
         res.header('Access-Control-Allow-Credentials', 'true');
+        res.header('Cross-Origin-Resource-Policy', 'same-site');
 
         const requestHeaders = req.header('Access-Control-Request-Headers');
         if (requestHeaders) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -109,6 +109,8 @@ app.use(`${appBasePath}/metrics`, (req, res) => {
 
 app.get(`${appBasePath}/isAlive`, (req, res) => res.sendStatus(200));
 app.get(`${appBasePath}/isReady`, (req, res) => res.sendStatus(200));
+
+// Static files
 app.use(
     `${appBasePath}/`,
     express.static(buildPath, {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -43,7 +43,6 @@ app.use((req, res, next) => {
         res.header('Access-Control-Allow-Origin', req.get('origin'));
         res.header('Access-Control-Allow-Methods', 'GET,HEAD,OPTIONS,POST,PUT');
         res.header('Access-Control-Allow-Credentials', 'true');
-        res.header('Cross-Origin-Resource-Policy', 'same-site');
 
         const requestHeaders = req.header('Access-Control-Request-Headers');
         if (requestHeaders) {
@@ -119,6 +118,9 @@ app.use(
                 res.header('Cache-Control', `max-age=${fiveMinutesInSeconds}`);
                 res.header('Pragma', `max-age=${fiveMinutesInSeconds}`);
             }
+
+            // Allow serving resources to sites using cross-origin isolation
+            res.header('Cross-Origin-Resource-Policy', 'same-site');
         },
     })
 );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,6 +92,7 @@ const commonConfig = {
                                             /\b(\w*close\w*)\b/,
                                             /\b(\w*decorator-dummy-app\w*)\b/,
                                             '.ReactModal__Overlay.ReactModal__Overlay--after-open.modal__overlay',
+                                            '#nav-chatbot',
                                         ],
                                     }),
                                     autoprefixer({}),


### PR DESCRIPTION
- Setter Cross-Origin-Resource-Policy på response-headere for statiske filer, slik at disse kan serveres på sider som benytter [cross-origin isolation](https://web.dev/coop-coep/)
- Fjerner ds-css. Denne blir pdd kun benyttet for en enkelt variabel i chatbot'en. Setter denne variablen på chatbot-containeren så lenge.