### PR TITLE
Bug fixes

### DIFF
--- a/src/komponenter/header/common/sprakvelger/SprakVelgerItem.tsx
+++ b/src/komponenter/header/common/sprakvelger/SprakVelgerItem.tsx
@@ -13,7 +13,7 @@ interface Props {
     selectedItem: LocaleOption | null;
     itemProps: any;
 }
-
+//
 const SprakVelgerItem = (props: Props) => {
     const { selectedItem, highlightedIndex, index } = props;
     const { item, itemProps, cls } = props;
@@ -33,7 +33,7 @@ const SprakVelgerItem = (props: Props) => {
             {selectedItem?.locale === item.locale ? (
                 <div className={cls.element('option')}>
                     <Bilde asset={Cicle} className={cls.element('sirkel')} />
-                    <Normaltekst lang={item.locale}>{item.label} </Normaltekst>
+                    <Normaltekst lang={item.locale}>{item.label}</Normaltekst>
                 </div>
             ) : (
                 <Normaltekst className={cls.element('option')}>

--- a/src/komponenter/header/common/sprakvelger/SprakVelgerItem.tsx
+++ b/src/komponenter/header/common/sprakvelger/SprakVelgerItem.tsx
@@ -13,7 +13,7 @@ interface Props {
     selectedItem: LocaleOption | null;
     itemProps: any;
 }
-//
+
 const SprakVelgerItem = (props: Props) => {
     const { selectedItem, highlightedIndex, index } = props;
     const { item, itemProps, cls } = props;

--- a/src/komponenter/header/header-regular/desktop/sok-dropdown/SokDropdown.tsx
+++ b/src/komponenter/header/header-regular/desktop/sok-dropdown/SokDropdown.tsx
@@ -13,7 +13,7 @@ import { SokKnapp } from 'komponenter/header/header-regular/desktop/sok-dropdown
 import './SokDropdown.less';
 
 export const sokDropdownClassname = 'desktop-sok-dropdown';
-export const desktopSokInputId = 'desktop-sok-input';
+export const desktopSokInputId = 'sok-input-large';
 const dropdownTransitionMs = 300;
 
 const stateSelector = (state: AppState) => ({

--- a/src/komponenter/header/header-regular/mobil/meny/innhold/Hovedmeny.tsx
+++ b/src/komponenter/header/header-regular/mobil/meny/innhold/Hovedmeny.tsx
@@ -23,7 +23,7 @@ interface Props {
     className: string;
 }
 
-export const mobilSokInputId = `mobil-sok-input`;
+export const mobilSokInputId = `sok-input-sm`;
 const stateSelector = (state: AppState) => ({
     meny: state.menypunkt,
     language: state.language.language,

--- a/src/komponenter/header/header-regular/mobil/meny/innhold/Hovedmeny.tsx
+++ b/src/komponenter/header/header-regular/mobil/meny/innhold/Hovedmeny.tsx
@@ -23,7 +23,7 @@ interface Props {
     className: string;
 }
 
-export const mobilSokInputId = `sok-input-sm`;
+export const mobilSokInputId = `sok-input-small`;
 const stateSelector = (state: AppState) => ({
     meny: state.menypunkt,
     language: state.language.language,


### PR DESCRIPTION
- Fikser mulig hydreringsfeil i språkvelger pga en utilsiktet "space" som noen apper ikke rendrer clientside
- Workaround for "smart" oppførsel på ios safari, der input-feltet for søk noen ganger automagisk tolkes som telefonnr-input pga id-felt som starter med "mobil"