### PR TITLE
Amplitude: Events for modal åpnet og modal lukket

### DIFF
--- a/src/komponenter/footer/common/del-skjerm-lenke/DelSkjermLenke.tsx
+++ b/src/komponenter/footer/common/del-skjerm-lenke/DelSkjermLenke.tsx
@@ -12,6 +12,7 @@ export const DelSkjermLenke = () => {
 
     const openModal = () => {
         analyticsEvent({
+            eventName: 'Modal åpnet',
             category: AnalyticsCategory.Footer,
             action: `kontakt/del-skjerm-open`,
         });
@@ -20,6 +21,7 @@ export const DelSkjermLenke = () => {
 
     const closeModal = () => {
         analyticsEvent({
+            eventName: 'Modal lukket',
             category: AnalyticsCategory.Footer,
             action: `kontakt/del-skjerm-close`,
         });

--- a/src/utils/analytics/analytics.ts
+++ b/src/utils/analytics/analytics.ts
@@ -17,6 +17,7 @@ export enum AnalyticsCategory {
 }
 
 export type AnalyticsEventArgs = {
+    eventName?: string;
     category: AnalyticsCategory;
     action: string;
     context?: MenuValue;
@@ -32,10 +33,10 @@ export const initAnalytics = (params: Params) => {
 };
 
 export const analyticsEvent = (props: AnalyticsEventArgs) => {
-    const { context, category, action, label, komponent, lenkegruppe } = props;
+    const { context, eventName, category, action, label, komponent, lenkegruppe } = props;
     const actionFinal = `${context ? context + '/' : ''}${action}`;
 
-    logAmplitudeEvent('navigere', {
+    logAmplitudeEvent(eventName || 'navigere', {
         destinasjon: label,
         lenketekst: actionFinal,
         kategori: category,


### PR DESCRIPTION
Kan nå sende inn eventName til logAmplitudeEvent.
Testet lokalt.