### PR TITLE
Fikser sjelden feil ved manglende target

### DIFF
--- a/src/komponenter/header/header-regular/common/sticky/StickyUtils.ts
+++ b/src/komponenter/header/header-regular/common/sticky/StickyUtils.ts
@@ -110,7 +110,8 @@ export const focusOverlapHandler = (stickyElement: HTMLElement) => (e: FocusEven
     }
 
     const headerHeight = stickyElement?.getBoundingClientRect().height;
-    const targetPos = (e.target as HTMLElement)?.getBoundingClientRect().top;
+    const target = e.target as HTMLElement;
+    const targetPos = target?.getBoundingClientRect && target.getBoundingClientRect().top;
 
     if (!headerHeight || targetPos === null || targetPos === undefined) {
         return;


### PR DESCRIPTION
Fikser feil relatert til
- https://sentry.gc.nav.no/organizations/nav/issues/69279/events/7d49f84b92184f21aff499b6ddf0f841/?project=131&query=is%3Aunresolved+%21level%3Ainfo
- https://sentry.gc.nav.no/organizations/nav/issues/96627/?query=is%3Aunresolved+%21level%3Ainfo&statsPeriod=14d#exception

hvor target ved noen få tilfeller ikke sendes med event-objektet.