### PR TITLE
Forbedrer feiltekst ved problemer rundt env-loading

### DIFF
--- a/src/utils/Environment.ts
+++ b/src/utils/Environment.ts
@@ -9,10 +9,16 @@ export const fetchEnv = (): Promise<Environment> => {
             const url = envDom.getAttribute('data-src');
             if (url) {
                 fetch(url, { credentials: 'include' })
-                    .then((result) => result.json())
+                    .then((result) => {
+                        if (result.status >= 200 && result.status <= 299) {
+                            return result.json();
+                        } else {
+                            throw Error(`Could not load env for dekoratøren: ${result.status} - ${result.statusText}`);
+                        }
+                    })
                     .then((result) => resolve(result))
                     .catch((error) => {
-                        throw error;
+                        throw Error(error);
                     });
             }
         } else {


### PR DESCRIPTION
Sentry rapporterer om feil ved innlasting av env-fil i dekoratøren (https://sentry.gc.nav.no/organizations/nav/issues/68230/events/6314ab3dc48c47dbb03eb06df7df0b5b/?project=131&query=is%3Aunresolved+%21level%3Ainfo), men det kommer ikke helt frem hva slags feilkode det dreier seg om.

Denne fiksen bør rapportere litt mer tydelig slik at vi kan etterforske feilen deretter.