### PR TITLE
Fiks font brodsmulesti

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -44,6 +44,7 @@ body.no-scroll-mobil {
 
 .site-skiplinks,
 .siteheader,
+.decorator-utils-container,
 .sitefooter {
     width: 100%;
     font-family: 'Source Sans Pro', Arial, sans-serif;

--- a/src/index.less
+++ b/src/index.less
@@ -42,9 +42,12 @@ body.no-scroll-mobil {
     }
 }
 
+.decorator-utils-container {
+    font-family: 'Source Sans Pro', Arial, sans-serif;
+}
+
 .site-skiplinks,
 .siteheader,
-.decorator-utils-container,
 .sitefooter {
     width: 100%;
     font-family: 'Source Sans Pro', Arial, sans-serif;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/71373910/184319791-b9cb2f33-d763-4b00-946a-d5091785e679.png)

Fikser font-family i brødsmulestien på innloggede sider som ikke er i enonic. Ble satt til Times New Roman

Eksempel: https://www.nav.no/person/personopplysninger/nb/