### PR TITLE
fiks-søkeknapp-plassering

### DIFF
--- a/src/komponenter/header/header-regular/common/sok/sok-innhold/SokInput.less
+++ b/src/komponenter/header/header-regular/common/sok/sok-innhold/SokInput.less
@@ -7,6 +7,10 @@
     .sok-input {
         margin: 0;
         width: 100%;
+
+        input {
+            margin-top: 0;
+        }
     }
     @media @screen-desktop {
         .sok-input {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/71373910/185090639-08d6edfa-eae1-4b18-8a85-1a74b027214e.png)

Quick-fix på desktop og mobil. Overrider margin-top som settes slik:

```
.navds-form-field > :not(:first-child):not(:empty),
.navds-form-field > input:not(:first-child) {
  margin-top: var(--navds-spacing-2);
```

Denne settes på nav.no men ikke på nav.no/dekoratoren. Skjønner ikke helt hvorfor/hvordan denne stylingen kommer fra..