### PR TITLE
Prefix scss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
                 "babel-preset-env": "^1.7.0",
                 "babel-preset-react-app": "^10.0.0",
                 "cross-env": "^7.0.3",
-                "css-loader": "^5.0.1",
+                "css-loader": "6.7.1",
                 "eslint": "^7.17.0",
                 "eslint-config-prettier": "^7.1.0",
                 "eslint-config-react-app": "^6.0.0",
@@ -7926,45 +7926,29 @@
             }
         },
         "node_modules/css-loader": {
-            "version": "5.2.7",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
-            "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
+            "integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
             "dev": true,
             "dependencies": {
                 "icss-utils": "^5.1.0",
-                "loader-utils": "^2.0.0",
-                "postcss": "^8.2.15",
+                "postcss": "^8.4.7",
                 "postcss-modules-extract-imports": "^3.0.0",
                 "postcss-modules-local-by-default": "^4.0.0",
                 "postcss-modules-scope": "^3.0.0",
                 "postcss-modules-values": "^4.0.0",
-                "postcss-value-parser": "^4.1.0",
-                "schema-utils": "^3.0.0",
+                "postcss-value-parser": "^4.2.0",
                 "semver": "^7.3.5"
             },
             "engines": {
-                "node": ">= 10.13.0"
+                "node": ">= 12.13.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.27.0 || ^5.0.0"
-            }
-        },
-        "node_modules/css-loader/node_modules/loader-utils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
+                "webpack": "^5.0.0"
             }
         },
         "node_modules/css-minimizer-webpack-plugin": {
@@ -31344,34 +31328,19 @@
             }
         },
         "css-loader": {
-            "version": "5.2.7",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
-            "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
+            "integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
             "dev": true,
             "requires": {
                 "icss-utils": "^5.1.0",
-                "loader-utils": "^2.0.0",
-                "postcss": "^8.2.15",
+                "postcss": "^8.4.7",
                 "postcss-modules-extract-imports": "^3.0.0",
                 "postcss-modules-local-by-default": "^4.0.0",
                 "postcss-modules-scope": "^3.0.0",
                 "postcss-modules-values": "^4.0.0",
-                "postcss-value-parser": "^4.1.0",
-                "schema-utils": "^3.0.0",
+                "postcss-value-parser": "^4.2.0",
                 "semver": "^7.3.5"
-            },
-            "dependencies": {
-                "loader-utils": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-                    "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
-                }
             }
         },
         "css-minimizer-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
         "babel-preset-env": "^1.7.0",
         "babel-preset-react-app": "^10.0.0",
         "cross-env": "^7.0.3",
-        "css-loader": "^5.0.1",
+        "css-loader": "6.7.1",
         "eslint": "^7.17.0",
         "eslint-config-prettier": "^7.1.0",
         "eslint-config-react-app": "^6.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,11 +105,32 @@ const commonConfig = {
                 },
             },
             {
+                test: /\.scss$/,
+                exclude: /\.module\.scss$/,
+                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader(), 'sass-loader'],
+            },
+            {
+                test: /\.module\.scss$/,
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            modules: {
+                                localIdentName: '[local]__[hash:base64:5]',
+                            },
+                        },
+                    },
+                    postCssLoader(':global(.decorator-wrapper)'),
+                    'sass-loader',
+                ],
+            },
+            {
                 test: /\.css$/,
                 include: /@navikt(\\|\/)ds-css/,
                 use: [
                     MiniCssExtractPlugin.loader,
-                    { loader: 'css-loader', options: {} },
+                    'css-loader',
                     {
                         loader: 'postcss-loader',
                         options: {
@@ -141,7 +162,7 @@ const commonConfig = {
                 exclude: /@navikt(\\|\/)ds-css/,
                 use: [
                     MiniCssExtractPlugin.loader,
-                    { loader: 'css-loader', options: {} },
+                    'css-loader',
                     {
                         loader: 'postcss-loader',
                         options: {
@@ -166,28 +187,7 @@ const commonConfig = {
                             },
                         },
                     },
-                    { loader: 'less-loader', options: {} },
-                ],
-            },
-            {
-                test: /\.scss$/,
-                exclude: /\.module\.scss$/,
-                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader(), 'sass-loader'],
-            },
-            {
-                test: /\.module\.scss$/,
-                use: [
-                    MiniCssExtractPlugin.loader,
-                    {
-                        loader: 'css-loader',
-                        options: {
-                            modules: {
-                                localIdentName: '[local]__[hash:base64:5]',
-                            },
-                        },
-                    },
-                    postCssLoader(':global(.decorator-wrapper)'),
-                    'sass-loader',
+                    'less-loader',
                 ],
             },
         ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,10 +97,6 @@ const commonConfig = {
                             postcssOptions: {
                                 ident: 'postcss',
                                 plugins: [
-                                    modifySelectors({
-                                        enabled: true,
-                                        replace: [{ match: ':root', with: '.decorator-wrapper' }],
-                                    }),
                                     prefixer({
                                         prefix: '.decorator-wrapper',
                                         exclude: prefixExclusions,
@@ -131,10 +127,6 @@ const commonConfig = {
                             postcssOptions: {
                                 ident: 'postcss',
                                 plugins: [
-                                    modifySelectors({
-                                        enabled: true,
-                                        replace: [{ match: ':root', with: '.decorator-wrapper' }],
-                                    }),
                                     prefixer({
                                         prefix: ':global(.decorator-wrapper)',
                                         exclude: prefixExclusions,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,41 @@ const autoprefixer = require('autoprefixer');
 const nodeExternals = require('webpack-node-externals');
 const modifySelectors = require('modify-selectors');
 
+const prefixExclusions = [
+    /\b(\w*(M|m)odal\w*)\b/,
+    'body',
+    'body.no-scroll-mobil',
+    '.siteheader',
+    '.sitefooter',
+    /\b(\w*lukk-container\w*)\b/,
+    /\b(\w*close\w*)\b/,
+    /\b(\w*decorator-dummy-app\w*)\b/,
+    '.ReactModal__Overlay.ReactModal__Overlay--after-open.modal__overlay',
+    '#nav-chatbot',
+    ':root',
+    '.decorator-wrapper',
+];
+
+const postCssLoader = {
+    loader: 'postcss-loader',
+    options: {
+        postcssOptions: {
+            ident: 'postcss',
+            plugins: [
+                modifySelectors({
+                    enabled: true,
+                    replace: [{ match: ':root', with: '.decorator-wrapper' }],
+                }),
+                prefixer({
+                    prefix: '.decorator-wrapper',
+                    exclude: prefixExclusions,
+                }),
+                autoprefixer({}),
+            ],
+        },
+    },
+};
+
 const commonConfig = {
     mode: process.env.NODE_ENV || 'development',
     devtool: 'source-map',
@@ -70,7 +105,7 @@ const commonConfig = {
             {
                 test: /\.scss$/,
                 exclude: /\.module\.scss$/,
-                use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader, 'sass-loader'],
             },
             {
                 test: /\.module\.scss$/,
@@ -89,43 +124,7 @@ const commonConfig = {
             },
             {
                 test: /\.(less|css)$/,
-                use: [
-                    MiniCssExtractPlugin.loader,
-                    { loader: 'css-loader', options: {} },
-                    {
-                        loader: 'postcss-loader',
-                        options: {
-                            postcssOptions: {
-                                ident: 'postcss',
-                                plugins: [
-                                    modifySelectors({
-                                        enabled: true,
-                                        replace: [{ match: ':root', with: '.decorator-wrapper' }],
-                                    }),
-                                    prefixer({
-                                        prefix: '.decorator-wrapper',
-                                        exclude: [
-                                            /\b(\w*(M|m)odal\w*)\b/,
-                                            'body',
-                                            'body.no-scroll-mobil',
-                                            '.siteheader',
-                                            '.sitefooter',
-                                            /\b(\w*lukk-container\w*)\b/,
-                                            /\b(\w*close\w*)\b/,
-                                            /\b(\w*decorator-dummy-app\w*)\b/,
-                                            '.ReactModal__Overlay.ReactModal__Overlay--after-open.modal__overlay',
-                                            '#nav-chatbot',
-                                            ':root',
-                                            '.decorator-wrapper',
-                                        ],
-                                    }),
-                                    autoprefixer({}),
-                                ],
-                            },
-                        },
-                    },
-                    { loader: 'less-loader', options: {} },
-                ],
+                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader, 'less-loader'],
             },
         ],
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,6 +123,25 @@ const commonConfig = {
                             },
                         },
                     },
+                    {
+                        loader: 'postcss-loader',
+                        options: {
+                            postcssOptions: {
+                                ident: 'postcss',
+                                plugins: [
+                                    modifySelectors({
+                                        enabled: true,
+                                        replace: [{ match: ':root', with: '.decorator-wrapper' }],
+                                    }),
+                                    prefixer({
+                                        prefix: ':global(.decorator-wrapper)',
+                                        exclude: prefixExclusions,
+                                    }),
+                                    autoprefixer({}),
+                                ],
+                            },
+                        },
+                    },
                     'sass-loader',
                 ],
             },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,6 +103,10 @@ const commonConfig = {
                 },
             },
             {
+                test: /\.(less|css)$/,
+                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader, 'less-loader'],
+            },
+            {
                 test: /\.scss$/,
                 exclude: /\.module\.scss$/,
                 use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader, 'sass-loader'],
@@ -121,10 +125,6 @@ const commonConfig = {
                     },
                     'sass-loader',
                 ],
-            },
-            {
-                test: /\.(less|css)$/,
-                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader, 'less-loader'],
             },
         ],
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,24 +23,26 @@ const prefixExclusions = [
     '.decorator-wrapper',
 ];
 
-const postCssLoader = {
-    loader: 'postcss-loader',
-    options: {
-        postcssOptions: {
-            ident: 'postcss',
-            plugins: [
-                modifySelectors({
-                    enabled: true,
-                    replace: [{ match: ':root', with: '.decorator-wrapper' }],
-                }),
-                prefixer({
-                    prefix: '.decorator-wrapper',
-                    exclude: prefixExclusions,
-                }),
-                autoprefixer({}),
-            ],
+const postCssLoader = (prefix = '.decorator-wrapper') => {
+    return {
+        loader: 'postcss-loader',
+        options: {
+            postcssOptions: {
+                ident: 'postcss',
+                plugins: [
+                    modifySelectors({
+                        enabled: true,
+                        replace: [{ match: ':root', with: '.decorator-wrapper' }],
+                    }),
+                    prefixer({
+                        prefix: prefix,
+                        exclude: prefixExclusions,
+                    }),
+                    autoprefixer({}),
+                ],
+            },
         },
-    },
+    };
 };
 
 const commonConfig = {
@@ -104,12 +106,12 @@ const commonConfig = {
             },
             {
                 test: /\.(less|css)$/,
-                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader, 'less-loader'],
+                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader(), 'less-loader'],
             },
             {
                 test: /\.scss$/,
                 exclude: /\.module\.scss$/,
-                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader, 'sass-loader'],
+                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader(), 'sass-loader'],
             },
             {
                 test: /\.module\.scss$/,
@@ -123,25 +125,7 @@ const commonConfig = {
                             },
                         },
                     },
-                    {
-                        loader: 'postcss-loader',
-                        options: {
-                            postcssOptions: {
-                                ident: 'postcss',
-                                plugins: [
-                                    modifySelectors({
-                                        enabled: true,
-                                        replace: [{ match: ':root', with: '.decorator-wrapper' }],
-                                    }),
-                                    prefixer({
-                                        prefix: ':global(.decorator-wrapper)',
-                                        exclude: prefixExclusions,
-                                    }),
-                                    autoprefixer({}),
-                                ],
-                            },
-                        },
-                    },
+                    postCssLoader(':global(.decorator-wrapper)'),
                     'sass-loader',
                 ],
             },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,41 +9,22 @@ const nodeExternals = require('webpack-node-externals');
 const modifySelectors = require('modify-selectors');
 
 const prefixExclusions = [
-    /\b(\w*(M|m)odal\w*)\b/,
     'body',
     'body.no-scroll-mobil',
     '.siteheader',
     '.sitefooter',
-    /\b(\w*lukk-container\w*)\b/,
-    /\b(\w*close\w*)\b/,
     /\b(\w*decorator-dummy-app\w*)\b/,
-    '.ReactModal__Overlay.ReactModal__Overlay--after-open.modal__overlay',
     '#nav-chatbot',
     ':root',
     '.decorator-wrapper',
 ];
 
-const postCssLoader = (prefix = '.decorator-wrapper') => {
-    return {
-        loader: 'postcss-loader',
-        options: {
-            postcssOptions: {
-                ident: 'postcss',
-                plugins: [
-                    modifySelectors({
-                        enabled: true,
-                        replace: [{ match: ':root', with: '.decorator-wrapper' }],
-                    }),
-                    prefixer({
-                        prefix: prefix,
-                        exclude: prefixExclusions,
-                    }),
-                    autoprefixer({}),
-                ],
-            },
-        },
-    };
-};
+const prefixExclusionsDsCss = [
+    '.decorator-wrapper',
+    /^\.navds-modal(:|--|$)/,
+    /^\.navds-modal__overlay/,
+    /^\.ReactModal/,
+];
 
 const commonConfig = {
     mode: process.env.NODE_ENV || 'development',
@@ -107,7 +88,30 @@ const commonConfig = {
             {
                 test: /\.scss$/,
                 exclude: /\.module\.scss$/,
-                use: [MiniCssExtractPlugin.loader, 'css-loader', postCssLoader(), 'sass-loader'],
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    'css-loader',
+                    {
+                        loader: 'postcss-loader',
+                        options: {
+                            postcssOptions: {
+                                ident: 'postcss',
+                                plugins: [
+                                    modifySelectors({
+                                        enabled: true,
+                                        replace: [{ match: ':root', with: '.decorator-wrapper' }],
+                                    }),
+                                    prefixer({
+                                        prefix: '.decorator-wrapper',
+                                        exclude: prefixExclusions,
+                                    }),
+                                    autoprefixer({}),
+                                ],
+                            },
+                        },
+                    },
+                    'sass-loader',
+                ],
             },
             {
                 test: /\.module\.scss$/,
@@ -121,7 +125,25 @@ const commonConfig = {
                             },
                         },
                     },
-                    postCssLoader(':global(.decorator-wrapper)'),
+                    {
+                        loader: 'postcss-loader',
+                        options: {
+                            postcssOptions: {
+                                ident: 'postcss',
+                                plugins: [
+                                    modifySelectors({
+                                        enabled: true,
+                                        replace: [{ match: ':root', with: '.decorator-wrapper' }],
+                                    }),
+                                    prefixer({
+                                        prefix: ':global(.decorator-wrapper)',
+                                        exclude: prefixExclusions,
+                                    }),
+                                    autoprefixer({}),
+                                ],
+                            },
+                        },
+                    },
                     'sass-loader',
                 ],
             },
@@ -143,12 +165,7 @@ const commonConfig = {
                                     }),
                                     prefixer({
                                         prefix: '.decorator-wrapper',
-                                        exclude: [
-                                            '.decorator-wrapper',
-                                            /^\.navds-modal(:|--|$)/,
-                                            /^\.navds-modal__overlay/,
-                                            /^\.ReactModal/,
-                                        ],
+                                        exclude: prefixExclusionsDsCss,
                                     }),
                                     autoprefixer({}),
                                 ],
@@ -171,16 +188,7 @@ const commonConfig = {
                                 plugins: [
                                     prefixer({
                                         prefix: '.decorator-wrapper',
-                                        exclude: [
-                                            'body',
-                                            'body.no-scroll-mobil',
-                                            '.siteheader',
-                                            '.sitefooter',
-                                            /\b(\w*decorator-dummy-app\w*)\b/,
-                                            '#nav-chatbot',
-                                            ':root',
-                                            '.decorator-wrapper',
-                                        ],
+                                        exclude: prefixExclusions,
                                     }),
                                     autoprefixer({}),
                                 ],


### PR DESCRIPTION
- Prefix Sass og Sass modules med decorator-wrapper
- Prefixing av modules er kanskje ikke egentlig nødvendig, men det fikser et problem med lavere spesifisitet (0,1,0) og overriding fra ds-css (som var prefixet og fikk spesifisitet (0,2,0)
- Rydding av nå unødvendige !important tar jeg i en egen branch