### PR TITLE
Rydd i !important-regler

### DIFF
--- a/src/komponenter/common/arbeidsflate-lenkepanel/ArbeidsflateLenkepanel.module.scss
+++ b/src/komponenter/common/arbeidsflate-lenkepanel/ArbeidsflateLenkepanel.module.scss
@@ -1,8 +1,8 @@
 @use 'src/styling-variabler' as sv;
 
 .arbeidsflateLenkepanel {
-    border: 2px var(--navds-global-color-blue-500) solid !important;
-    border-radius: 4px !important;
+    border: 2px var(--navds-global-color-blue-500) solid;
+    border-radius: 4px;
     margin-bottom: 0;
 
     &:hover {
@@ -13,7 +13,7 @@
         :global(.navds-link-panel__title),
         :global(.navds-link-panel__description),
         :global(.compact-chevron) {
-            color: var(--navds-global-color-white) !important;
+            color: var(--navds-global-color-white);
         }
 
         :global(.compact-chevron) {
@@ -67,7 +67,7 @@
     @media #{sv.$screen-desktop-small-down} {
         padding: 0.5rem 0.75rem;
         margin-bottom: 0.25rem;
-        border: none !important;
+        border: none;
 
         :global(.navds-link-panel__chevron) {
             display: none;

--- a/src/komponenter/footer/common/del-skjerm-modal/DelSkjermModal.module.scss
+++ b/src/komponenter/footer/common/del-skjerm-modal/DelSkjermModal.module.scss
@@ -2,7 +2,7 @@
 
 .delskjerm {
     max-width: 35rem;
-    overflow: visible !important;
+    overflow: visible;
     padding: 1rem;
 }
 

--- a/src/komponenter/header/Header.scss
+++ b/src/komponenter/header/Header.scss
@@ -6,10 +6,10 @@
     justify-items: center;
 
     &--white {
-        background: var(--navds-semantic-color-canvas-background-light) !important;
+        background: var(--navds-semantic-color-canvas-background-light);
     }
     &--gray {
-        background: var(--navds-semantic-color-canvas-background) !important;
+        background: var(--navds-semantic-color-canvas-background);
     }
 }
 

--- a/src/komponenter/header/header-regular/common/logg-inn/LoggInnKnapp.module.scss
+++ b/src/komponenter/header/header-regular/common/logg-inn/LoggInnKnapp.module.scss
@@ -8,7 +8,7 @@
 .loginKnapp {
     @include MenylinjeKnappMixin.menylinjeKnappMixin;
     align-self: center;
-    opacity: 1 !important; //override opacity i navds
+    opacity: 1;
 
     .loginIconLoading {
         animation-name: loading;

--- a/src/komponenter/header/header-regular/common/meny-lenker/MenyLenker.module.scss
+++ b/src/komponenter/header/header-regular/common/meny-lenker/MenyLenker.module.scss
@@ -9,12 +9,12 @@
 }
 
 .tittel {
-    margin-bottom: 0.1875rem !important; //override navds
+    margin-bottom: 0.1875rem;
 
     @media #{sv.$screen-desktop-small-down} {
-        font-size: 16px !important; //override navds
-        line-height: 22px !important; //override navds
-        margin-bottom: 0.125rem !important; //override navds
+        font-size: 16px;
+        line-height: 22px;
+        margin-bottom: 0.125rem;
     }
 }
 

--- a/src/komponenter/header/header-regular/common/minside-lock-msg/MinsideLockMsg.module.scss
+++ b/src/komponenter/header/header-regular/common/minside-lock-msg/MinsideLockMsg.module.scss
@@ -7,8 +7,8 @@
     margin-bottom: 2rem;
     margin-top: 0;
     padding: 1rem;
-    background-color: var(--navds-global-color-lightblue-100) !important; //override navds
-    border: 2px solid var(--navds-global-color-lightblue-500) !important; //override navds
+    background-color: var(--navds-global-color-lightblue-100);
+    border: 2px solid var(--navds-global-color-lightblue-500);
 
     @media #{sv.$screen-mobile} {
         margin-bottom: 1rem;

--- a/src/komponenter/header/header-regular/common/sticky/Sticky.module.scss
+++ b/src/komponenter/header/header-regular/common/sticky/Sticky.module.scss
@@ -30,7 +30,7 @@
 
 .stickyContainerMobilFixed {
     @media #{sv.$screen-mobile} {
-        position: fixed !important;
-        top: 0 !important;
+        position: fixed;
+        top: 0;
     }
 }

--- a/src/komponenter/header/header-regular/common/varsler/varselvisning/varsel-liste/VarselListe.module.scss
+++ b/src/komponenter/header/header-regular/common/varsler/varselvisning/varsel-liste/VarselListe.module.scss
@@ -31,10 +31,10 @@
 }
 
 .varselDato {
-    margin-bottom: 0.25rem !important; //override navds
-    font-weight: 400 !important; //override navds
+    margin-bottom: 0.25rem;
+    font-weight: 400;
 }
 
 .infotekst {
-    margin-bottom: 0.5rem !important; //override navds
+    margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
Fjerner important-regler som ikke lenger trengs nå som "alt" prefixes med .decorator-wrapper