### PR TITLE
Forhindre at flexbox endrer størrelsen på logo

### DIFF
--- a/src/komponenter/common/nav-logo/NavLogoLenke.module.scss
+++ b/src/komponenter/common/nav-logo/NavLogoLenke.module.scss
@@ -1,5 +1,6 @@
 .navLogoLenke {
     display: flex;
+    flex: none;
 
     &:focus {
         box-shadow: 0 0 0 4px var(--navds-semantic-color-focus) inset;


### PR DESCRIPTION
Denne endringen gjør dekoratøren litt mer robust 🧑‍🏭 

## Bakgrunn
Stylingen i kalkulator-appen på https://www.nav.no/aap/kalkulator bruker Tailwind CSS. Base-stilen inneholder regler som setter `max-width: 100%` på `img` og `video`. Dette var nok til å trigge krymping av logo-bildet i dekoratøren, siden denne koden ikke har scopet element-stilene og treffer «alt». De hadde lagt inn en quickfix som satte `max-width` på alle bilder til `200%`, men den fikset bare skvis av logo og ikke avstanden til lenkene.