### PR TITLE
⬆️ Oppdatert til designsystemet v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
             "name": "nav-dekoratoren",
             "version": "1.0.0",
             "dependencies": {
-                "@navikt/ds-css": "1.3.21",
-                "@navikt/ds-icons": "1.3.21",
-                "@navikt/ds-react": "1.3.21",
-                "@navikt/ds-tokens": "1.3.21",
+                "@navikt/ds-css": "2.0.0",
+                "@navikt/ds-icons": "2.0.0",
+                "@navikt/ds-react": "2.0.0",
+                "@navikt/ds-tokens": "2.0.0",
                 "@navikt/nav-chatbot": "2.7.4",
                 "@navikt/nav-dekoratoren-moduler": "1.7.0",
                 "@promster/express": "5.1.3",
@@ -3213,15 +3213,15 @@
             }
         },
         "node_modules/@navikt/ds-css": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/1.3.21/4ab1893d582f021e9f000f3be2ee50bbdf7a8bf4",
-            "integrity": "sha512-8TgBpXlvEf3/0QpAQWy0o28AE987+AiOGWom+aWx+BfBj+xlnbvbW25cUdCBRTj/xSqN7ziGbJZ3KGJCbAMztg==",
+            "version": "2.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/2.0.0/dedf794aea27f12283a5545a629c2fa9b6902568",
+            "integrity": "sha512-1LvUoH2dXrNn844A37UJxgccLWRAUapoCR1/6kifiYt1PK+E4pdzwlmF+fSjw5P4i7gGzO8D73aYlDCvknHakA==",
             "license": "MIT"
         },
         "node_modules/@navikt/ds-icons": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/1.3.21/5f6e637f73f3c8b8b6f2a7d0005b254773487b7f",
-            "integrity": "sha512-ghbUqmFR6LOB3SiZnNJHZHuVWB50RSWy052Ea+fhzIFxs2IcVR9wFpnL5PJW0c/4yjVhDu1BVGUSYVjfgqd4Sg==",
+            "version": "2.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/2.0.0/4980351716452d7fbf9e4a82dc069c1f1fb3f735",
+            "integrity": "sha512-7MiTauDPjT8y68B8UuvxUAEz7gTSVWMyJGDjuXGjWagRntoLbbLKaI6BT3UEaKCoOAUM/ZX77snd+taEE7n35w==",
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^17.0.30 || ^18.0.0",
@@ -3229,13 +3229,13 @@
             }
         },
         "node_modules/@navikt/ds-react": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/1.3.21/f8fc6665b227dd0d650aff398678916aa802e66e",
-            "integrity": "sha512-s1hlLoQ05NTIhR3h+4laRsyaxaGh/RvntYWt8G5A2YVP34mWqKiw6wV4ilNmpbSVFnJ/6mvzSM2ScPTRA//Qww==",
+            "version": "2.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/2.0.0/9ad729b72fcd85a0ac53203c5e9ac0d8b0df38c6",
+            "integrity": "sha512-56POeydW7BsuqMJAhHWXvCINDok2Gniv8n3q+T2qs6rfGXI1P8v4PF3+QbasZlrGjfWN73HjfqrLNo9k70ntkg==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/react-dom-interactions": "0.9.2",
-                "@navikt/ds-icons": "^1.3.21",
+                "@navikt/ds-icons": "^2.0.0",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
                 "clsx": "^1.2.1",
@@ -3249,9 +3249,9 @@
             }
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/1.3.21/277f7434a8023cd58d2071fcd6942e0017cf9646",
-            "integrity": "sha512-VstkLAu2j43d1vRC6ZwBHBIQ/fm6HqeTHXTqEhH60SG3JOMANfpN4gTrnmZfqlSiBuiEUdnRKsp5MpWfWquVTA==",
+            "version": "2.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/2.0.0/1d5eb03445ada0a55b468446bcdfa62f5a3860cd",
+            "integrity": "sha512-FYwKKMnCXlBuFPiqb32zK6nqpmukrr/1EnXJvszLoCv/VHdhxB/Szn01lur5utH5sfGMrAkwii8YQPqETys3PQ==",
             "license": "MIT"
         },
         "node_modules/@navikt/fnrvalidator": {
@@ -26629,23 +26629,23 @@
             }
         },
         "@navikt/ds-css": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/1.3.21/4ab1893d582f021e9f000f3be2ee50bbdf7a8bf4",
-            "integrity": "sha512-8TgBpXlvEf3/0QpAQWy0o28AE987+AiOGWom+aWx+BfBj+xlnbvbW25cUdCBRTj/xSqN7ziGbJZ3KGJCbAMztg=="
+            "version": "2.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/2.0.0/dedf794aea27f12283a5545a629c2fa9b6902568",
+            "integrity": "sha512-1LvUoH2dXrNn844A37UJxgccLWRAUapoCR1/6kifiYt1PK+E4pdzwlmF+fSjw5P4i7gGzO8D73aYlDCvknHakA=="
         },
         "@navikt/ds-icons": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/1.3.21/5f6e637f73f3c8b8b6f2a7d0005b254773487b7f",
-            "integrity": "sha512-ghbUqmFR6LOB3SiZnNJHZHuVWB50RSWy052Ea+fhzIFxs2IcVR9wFpnL5PJW0c/4yjVhDu1BVGUSYVjfgqd4Sg==",
+            "version": "2.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/2.0.0/4980351716452d7fbf9e4a82dc069c1f1fb3f735",
+            "integrity": "sha512-7MiTauDPjT8y68B8UuvxUAEz7gTSVWMyJGDjuXGjWagRntoLbbLKaI6BT3UEaKCoOAUM/ZX77snd+taEE7n35w==",
             "requires": {}
         },
         "@navikt/ds-react": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/1.3.21/f8fc6665b227dd0d650aff398678916aa802e66e",
-            "integrity": "sha512-s1hlLoQ05NTIhR3h+4laRsyaxaGh/RvntYWt8G5A2YVP34mWqKiw6wV4ilNmpbSVFnJ/6mvzSM2ScPTRA//Qww==",
+            "version": "2.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/2.0.0/9ad729b72fcd85a0ac53203c5e9ac0d8b0df38c6",
+            "integrity": "sha512-56POeydW7BsuqMJAhHWXvCINDok2Gniv8n3q+T2qs6rfGXI1P8v4PF3+QbasZlrGjfWN73HjfqrLNo9k70ntkg==",
             "requires": {
                 "@floating-ui/react-dom-interactions": "0.9.2",
-                "@navikt/ds-icons": "^1.3.21",
+                "@navikt/ds-icons": "^2.0.0",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
                 "clsx": "^1.2.1",
@@ -26655,9 +26655,9 @@
             }
         },
         "@navikt/ds-tokens": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/1.3.21/277f7434a8023cd58d2071fcd6942e0017cf9646",
-            "integrity": "sha512-VstkLAu2j43d1vRC6ZwBHBIQ/fm6HqeTHXTqEhH60SG3JOMANfpN4gTrnmZfqlSiBuiEUdnRKsp5MpWfWquVTA=="
+            "version": "2.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/2.0.0/1d5eb03445ada0a55b468446bcdfa62f5a3860cd",
+            "integrity": "sha512-FYwKKMnCXlBuFPiqb32zK6nqpmukrr/1EnXJvszLoCv/VHdhxB/Szn01lur5utH5sfGMrAkwii8YQPqETys3PQ=="
         },
         "@navikt/fnrvalidator": {
             "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
         "url": "https://github.com/navikt/nav-dekoratoren/issues"
     },
     "dependencies": {
-        "@navikt/ds-css": "1.3.21",
-        "@navikt/ds-icons": "1.3.21",
-        "@navikt/ds-react": "1.3.21",
-        "@navikt/ds-tokens": "1.3.21",
+        "@navikt/ds-css": "2.0.0",
+        "@navikt/ds-icons": "2.0.0",
+        "@navikt/ds-react": "2.0.0",
+        "@navikt/ds-tokens": "2.0.0",
         "@navikt/nav-chatbot": "2.7.4",
         "@navikt/nav-dekoratoren-moduler": "1.7.0",
         "@promster/express": "5.1.3",

--- a/src/csp.ts
+++ b/src/csp.ts
@@ -13,6 +13,7 @@ const googleTagManager = '*.googletagmanager.com';
 const hotjarCom = '*.hotjar.com';
 const hotjarIo = '*.hotjar.io';
 const taskAnalytics = '*.taskanalytics.com';
+const navCdn = 'https://cdn.nav.no';
 
 const styleSrc = [
     navno,
@@ -45,6 +46,7 @@ const directives: Partial<CSPDirectives> = {
     'font-src': [
         vergicScreenSharing,
         hotjarCom,
+        navCdn,
         DATA, // ds-css
     ],
     'img-src': [navno, vergicScreenSharing, googleAnalytics, vimeoCdn, hotjarCom, googleTagManager, vergicDotCom],

--- a/src/head.ts
+++ b/src/head.ts
@@ -43,6 +43,16 @@ const getTagsData = (appUrl: string): Tag[] => [
             href: `${appUrl}${webManifest}`,
         },
     },
+    {
+        tag: 'link',
+        attribs: {
+            rel: 'preload',
+            href: `https://cdn.nav.no/aksel/fonts/SourceSans3-normal.woff2`,
+            as: 'font',
+            type: 'font/woff2',
+            crossorigin: 'true',
+        },
+    },
 ];
 
 export const injectHeadTags = (appUrl: string) => {

--- a/src/komponenter/common/arbeidsflate-lenkepanel/ArbeidsflateLenkepanel.module.scss
+++ b/src/komponenter/common/arbeidsflate-lenkepanel/ArbeidsflateLenkepanel.module.scss
@@ -1,24 +1,24 @@
 @use 'src/styling-variabler' as sv;
 
 :global(.arbeidsflate-lenkepanel) {
-    border: 2px var(--navds-global-color-blue-500) solid;
+    border: 2px var(--a-blue-500) solid;
     border-radius: 4px;
     margin-bottom: 0;
 
     &:hover {
-        border: 2px var(--navds-global-color-blue-500 solid);
-        background-color: var(--navds-global-color-blue-500);
+        border: 2px var(--a-blue-500 solid);
+        background-color: var(--a-blue-500);
 
         :global(.navds-link-panel__chevron),
         :global(.navds-link-panel__title),
         :global(.navds-link-panel__description),
         :global(.compact-chevron) {
-            color: var(--navds-global-color-white);
+            color: var(--a-white);
         }
 
         :global(.compact-chevron) {
             transform: translateX(6px);
-            stroke: var(--navds-global-color-white);
+            stroke: var(--a-white);
         }
     }
 
@@ -27,11 +27,11 @@
     }
 
     :global(.navds-link-panel__title) {
-        color: var(--navds-global-color-blue-500);
+        color: var(--a-blue-500);
     }
 
     :global(.navds-link-panel__chevron) {
-        color: var(--navds-global-color-blue-500);
+        color: var(--a-blue-500);
     }
 
     :global(.compact-chevron) {
@@ -39,7 +39,7 @@
         align-self: center;
         margin-right: 8px;
         margin-left: -4px;
-        stroke: var(--navds-global-color-blue-500);
+        stroke: var(--a-blue-500);
         transition: transform 0.25s;
     }
 
@@ -60,7 +60,7 @@
 
     :global(.navds-link-panel__description) {
         font-size: 1.1rem;
-        margin-top: var(--navds-spacing-1);
+        margin-top: var(--a-spacing-1);
         line-height: 1.5rem;
     }
 

--- a/src/komponenter/common/lenke-med-sporing/LenkeMedSporing.module.scss
+++ b/src/komponenter/common/lenke-med-sporing/LenkeMedSporing.module.scss
@@ -20,8 +20,8 @@
         outline: none;
         color: #fff;
         text-decoration: none;
-        background-color: var(--navds-semantic-color-focus);
-        box-shadow: 0 0 0 2px var(--navds-semantic-color-focus);
+        background-color: var(--a-border-focus);
+        box-shadow: 0 0 0 2px var(--a-border-focus);
 
         svg,
         path {
@@ -32,8 +32,8 @@
     & svg {
         width: 1em;
         height: 1em;
-        fill: var(--navds-semantic-color-link);
-        stroke: var(--navds-semantic-color-link);
+        fill: var(--a-text-action);
+        stroke: var(--a-text-action);
         vertical-align: middle;
         position: relative;
         top: -0.125em;

--- a/src/komponenter/common/nav-logo/NavLogoLenke.module.scss
+++ b/src/komponenter/common/nav-logo/NavLogoLenke.module.scss
@@ -3,7 +3,7 @@
     flex: none;
 
     &:focus {
-        box-shadow: 0 0 0 4px var(--navds-semantic-color-focus) inset;
+        box-shadow: 0 0 0 4px var(--a-border-focus) inset;
         border-radius: 8px;
         outline: none;
         border-color: transparent;

--- a/src/komponenter/footer/footer-regular/footer-bottom/FooterBottom.module.scss
+++ b/src/komponenter/footer/footer-regular/footer-bottom/FooterBottom.module.scss
@@ -1,7 +1,7 @@
 @use 'src/styling-variabler' as sv;
 
 .menylinjeBottom {
-    background-color: var(--navds-global-color-deepblue-800);
+    background-color: var(--a-deepblue-800);
     color: white;
     display: flex;
     justify-content: center;

--- a/src/komponenter/footer/footer-regular/footer-topp/FooterTopp.module.scss
+++ b/src/komponenter/footer/footer-regular/footer-topp/FooterTopp.module.scss
@@ -1,7 +1,7 @@
 @use 'src/styling-variabler' as sv;
 
 .menylinjeTopp {
-    background-color: var(--navds-global-color-deepblue-800);
+    background-color: var(--a-deepblue-800);
 }
 
 .toppKontainer {
@@ -26,12 +26,12 @@
         }
 
         &:focus {
-            color: var(--navds-global-color-blue-500);
+            color: var(--a-blue-500);
             background-color: white;
 
             svg {
-                stroke: var(--navds-global-color-blue-500);
-                color: var(--navds-global-color-blue-500);
+                stroke: var(--a-blue-500);
+                color: var(--a-blue-500);
             }
         }
     }

--- a/src/komponenter/header/Header.scss
+++ b/src/komponenter/header/Header.scss
@@ -6,10 +6,10 @@
     justify-items: center;
 
     &--white {
-        background: var(--navds-semantic-color-canvas-background-light);
+        background: var(--a-bg-default);
     }
     &--gray {
-        background: var(--navds-semantic-color-canvas-background);
+        background: var(--a-bg-subtle);
     }
 }
 

--- a/src/komponenter/header/common/brodsmulesti/Brodsmulesti.module.scss
+++ b/src/komponenter/header/common/brodsmulesti/Brodsmulesti.module.scss
@@ -34,8 +34,8 @@
     align-items: center;
 
     svg * {
-        stroke: var(--navds-global-color-gray-600);
-        fill: var(--navds-global-color-gray-600);
+        stroke: var(--a-gray-600);
+        fill: var(--a-gray-600);
     }
 
     .iconHome {
@@ -47,7 +47,7 @@
     }
 
     &:focus .iconHome {
-        color: var(--navds-global-color-gray-600);
+        color: var(--a-gray-600);
     }
 }
 

--- a/src/komponenter/header/common/driftsmeldinger/Driftsmeldinger.module.scss
+++ b/src/komponenter/header/common/driftsmeldinger/Driftsmeldinger.module.scss
@@ -1,11 +1,11 @@
 @use 'src/styling-variabler' as sv;
 
 .driftsmeldinger {
-    background-color: var(--navds-global-color-deepblue-600);
+    background-color: var(--a-deepblue-600);
     display: flex;
     flex-wrap: wrap;
     padding: 0.5rem 0;
-    color: var(--navds-global-color-white);
+    color: var(--a-white);
 
     @media #{sv.$screen-mobile} {
         justify-content: start;
@@ -20,7 +20,7 @@
 }
 
 .message {
-    color: var(--navds-global-color-white);
+    color: var(--a-white);
     padding: 0.5rem;
     display: inline-flex;
     align-items: center;
@@ -41,7 +41,7 @@
     }
 
     &:focus {
-        box-shadow: 0 0 0 3px var(--navds-global-color-white);
+        box-shadow: 0 0 0 3px var(--a-white);
         outline: none;
     }
 }
@@ -49,5 +49,5 @@
     display: flex;
     align-items: center;
     margin-right: 0.5rem;
-    color: var(--navds-global-color-white);
+    color: var(--a-white);
 }

--- a/src/komponenter/header/common/skiplinks/Skiplinks.scss
+++ b/src/komponenter/header/common/skiplinks/Skiplinks.scss
@@ -31,8 +31,8 @@
             outline: none;
             color: white;
             text-decoration: none;
-            background-color: var(--navds-semantic-color-focus);
-            box-shadow: 0 0 0 2px var(--navds-semantic-color-focus);
+            background-color: var(--a-border-focus);
+            box-shadow: 0 0 0 2px var(--a-border-focus);
         }
 
         &__mobil {

--- a/src/komponenter/header/common/sprakvelger/SprakVelger.module.scss
+++ b/src/komponenter/header/common/sprakvelger/SprakVelger.module.scss
@@ -76,7 +76,7 @@
     padding: 0.5rem;
     cursor: pointer;
     display: flex;
-    border: 1px solid var(--navds-global-color-gray-200);
+    border: 1px solid var(--a-gray-200);
     box-sizing: border-box;
 
     &:not(:last-child) {

--- a/src/komponenter/header/header-regular/HeaderMenylinje.module.scss
+++ b/src/komponenter/header/header-regular/HeaderMenylinje.module.scss
@@ -51,7 +51,7 @@
 
 .minsideKnapper {
     @media #{sv.$screen-desktop} {
-        background-color: var(--navds-semantic-color-interaction-primary-hover-subtle);
+        background-color: var(--a-surface-action-subtle-hover);
     }
 
     @media #{sv.$screen-mobile} {

--- a/src/komponenter/header/header-regular/common/browser-support-msg/BrowserSupportMsg.module.scss
+++ b/src/komponenter/header/header-regular/common/browser-support-msg/BrowserSupportMsg.module.scss
@@ -1,7 +1,7 @@
 @use 'src/styling-variabler' as sv;
 
 .wrapper {
-    background-color: var(--navds-global-color-orange-100);
+    background-color: var(--a-orange-100);
     border-bottom: sv.$header-separator-farge 2px solid;
 }
 

--- a/src/komponenter/header/header-regular/common/meny-knapp/MenylinjeKnappMixin.scss
+++ b/src/komponenter/header/header-regular/common/meny-knapp/MenylinjeKnappMixin.scss
@@ -8,22 +8,22 @@
     white-space: nowrap;
 
     &:hover {
-        box-shadow: inset 0 0 0 2px var(--navds-semantic-color-interaction-primary);
+        box-shadow: inset 0 0 0 2px var(--a-surface-action);
     }
 
     &:active {
         :global(.hamburger-ikon) {
             span {
-                background-color: var(--navds-global-color-white);
+                background-color: var(--a-white);
             }
         }
         :global(.sok-ikon) {
             :global(.sok-ikon__line),
             :global(.sok-ikon__line-x) {
-                background-color: var(--navds-global-color-white);
+                background-color: var(--a-white);
             }
             :global(.sok-ikon__circle) {
-                border-color: var(--navds-global-color-white);
+                border-color: var(--a-white);
                 background-color: transparent;
             }
         }
@@ -35,6 +35,6 @@
     }
 
     :global(.navds-button__icon) {
-        --navds-button-icon-adjustment: 0;
+        --v2-migration__navds-button-icon-adjustment: 0;
     }
 }

--- a/src/komponenter/header/header-regular/common/minside-lock-msg/MinsideLockMsg.module.scss
+++ b/src/komponenter/header/header-regular/common/minside-lock-msg/MinsideLockMsg.module.scss
@@ -7,8 +7,8 @@
     margin-bottom: 2rem;
     margin-top: 0;
     padding: 1rem;
-    background-color: var(--navds-global-color-lightblue-100);
-    border: 2px solid var(--navds-global-color-lightblue-500);
+    background-color: var(--a-lightblue-100);
+    border: 2px solid var(--a-lightblue-500);
 
     @media #{sv.$screen-mobile} {
         margin-bottom: 1rem;
@@ -21,13 +21,13 @@
     height: 3rem;
     margin-right: 0.625rem;
     padding: 0.75rem 1rem;
-    background-color: var(--navds-global-color-lightblue-300);
+    background-color: var(--a-lightblue-300);
     border-radius: 1.5rem;
 
     svg {
         width: 1rem;
         g {
-            fill: var(--navds-global-color-gray-800);
+            fill: var(--a-gray-800);
         }
     }
 }

--- a/src/komponenter/header/header-regular/common/sok/sok-innhold/SokInput.scss
+++ b/src/komponenter/header/header-regular/common/sok/sok-innhold/SokInput.scss
@@ -17,7 +17,7 @@
         .sok-input {
             input {
                 padding: 0.75rem;
-                border: 2px solid var(--navds-global-color-blue-500);
+                border: 2px solid var(--a-blue-500);
                 &::-ms-clear {
                     display: none;
                 }
@@ -49,11 +49,11 @@
             input {
                 padding: 0.7rem 1rem;
                 background-color: white;
-                border: 2px solid var(--navds-global-color-blue-500);
+                border: 2px solid var(--a-blue-500);
 
                 &:focus,
                 &:active {
-                    border: 2px solid var(--navds-global-color-blue-500);
+                    border: 2px solid var(--a-blue-500);
                 }
             }
             .skjemaelement__input {

--- a/src/komponenter/header/header-regular/common/sok/sok-innhold/SokKnapper.scss
+++ b/src/komponenter/header/header-regular/common/sok/sok-innhold/SokKnapper.scss
@@ -13,11 +13,11 @@
     height: 100%;
     background: none;
     align-items: center;
-    color: var(--navds-global-color-blue-500);
+    color: var(--a-blue-500);
     padding: 0 1rem;
     font-weight: 600;
-    border-top: 3px solid var(--navds-global-color-blue-500);
-    border-bottom: 3px solid var(--navds-global-color-blue-500);
+    border-top: 3px solid var(--a-blue-500);
+    border-bottom: 3px solid var(--a-blue-500);
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
     cursor: pointer;
@@ -27,13 +27,13 @@
     z-index: 1;
     outline: 0;
     background-color: white;
-    box-shadow: 0 0 0 3px var(--navds-semantic-color-focus);
-    color: var(--navds-global-color-blue-500);
+    box-shadow: 0 0 0 3px var(--a-border-focus);
+    color: var(--a-blue-500);
     border: 3px solid transparent;
 }
 
 .sok-knapper__knapp:hover {
-    border-color: var(--navds-global-color-blue-500);
+    border-color: var(--a-blue-500);
 }
 
 .sok-knapper__knapp-avbryt {
@@ -52,15 +52,15 @@
     .sok-knapper__knapp-submit {
         border-radius: 0 3px 3px 0;
         color: white;
-        background-color: var(--navds-global-color-blue-500);
+        background-color: var(--a-blue-500);
     }
 
     .sok-knapper__knapp-submit .sok-ikon__line {
-        background-color: var(--navds-global-color-white);
+        background-color: var(--a-white);
     }
 
     .sok-knapper__knapp-submit .sok-ikon > * {
-        border-color: var(--navds-global-color-white);
+        border-color: var(--a-white);
     }
 
     .sok-knapper__knapp-submit:active,
@@ -81,11 +81,11 @@
     }
 
     .sok-knapper__knapp-submit:focus .sok-ikon__line {
-        background-color: var(--navds-global-color-blue-500);
+        background-color: var(--a-blue-500);
     }
 
     .sok-knapper__knapp-submit:focus .sok-ikon > * {
-        border-color: var(--navds-global-color-blue-500);
+        border-color: var(--a-blue-500);
     }
 
     .sok-knapper__ikon-container {

--- a/src/komponenter/header/header-regular/common/sok/sok-innhold/SokResultater.scss
+++ b/src/komponenter/header/header-regular/common/sok/sok-innhold/SokResultater.scss
@@ -29,8 +29,8 @@
             outline: none;
             color: white;
             text-decoration: none;
-            background-color: var(--navds-global-color-deepblue-500);
-            box-shadow: 0 0 0 2px var(--navds-global-color-deepblue-500);
+            background-color: var(--a-deepblue-500);
+            box-shadow: 0 0 0 2px var(--a-deepblue-500);
         }
     }
 
@@ -48,19 +48,19 @@
             animation-delay: calc(var(--index) * 50ms);
             animation-fill-mode: both;
             animation-timing-function: ease-in-out;
-            border-bottom: 1px solid var(--navds-global-color-gray-400);
+            border-bottom: 1px solid var(--a-gray-400);
             margin: 0 -0.5rem;
             padding: 0 0.5rem;
 
             &:focus,
             &:hover {
-                background-color: var(--navds-global-color-gray-300);
+                background-color: var(--a-gray-300);
                 font-weight: bold;
             }
         }
 
         li[aria-selected='true'] {
-            background-color: var(--navds-global-color-gray-300);
+            background-color: var(--a-gray-300);
             font-weight: bold;
         }
 
@@ -101,7 +101,7 @@
             }
 
             li[aria-selected='true'] {
-                background-color: var(--navds-global-color-gray-300);
+                background-color: var(--a-gray-300);
                 font-weight: bold;
             }
 

--- a/src/komponenter/header/header-regular/common/varsler/varselvisning/varsel-liste/VarselListe.module.scss
+++ b/src/komponenter/header/header-regular/common/varsler/varselvisning/varsel-liste/VarselListe.module.scss
@@ -1,5 +1,5 @@
 .varselContainer {
-    $separator-props: var(--navds-global-color-gray-800) solid 1px;
+    $separator-props: var(--a-gray-800) solid 1px;
     border-top: $separator-props;
     border-bottom: $separator-props;
 }

--- a/src/komponenter/header/header-regular/common/varsler/varsler-knapp/varsel-ikon/VarselIkon.module.scss
+++ b/src/komponenter/header/header-regular/common/varsler/varsler-knapp/varsel-ikon/VarselIkon.module.scss
@@ -1,6 +1,6 @@
 @use 'src/styling-variabler' as sv;
 
-$main-color: var(--navds-global-color-blue-500);
+$main-color: var(--a-blue-500);
 $transition-duration: 0.35s;
 $transition: all $transition-duration ease-in;
 $ulest-diameter: 12px;
@@ -20,7 +20,7 @@ $ulest-diameter: 12px;
         top: 14px;
     }
 
-    background-color: var(--navds-semantic-color-feedback-danger-icon);
+    background-color: var(--a-icon-danger);
 
     display: flex;
     justify-content: center;

--- a/src/komponenter/header/header-regular/desktop/arbeidsflatemeny/Arbeidsflatemeny.module.scss
+++ b/src/komponenter/header/header-regular/desktop/arbeidsflatemeny/Arbeidsflatemeny.module.scss
@@ -28,29 +28,29 @@ $underline-height: 4px;
     height: calc(100% + #{$separator-height});
     display: inline-block;
     text-decoration: none;
-    color: var(--navds-semantic-color-text-muted);
+    color: var(--a-text-subtle);
 
     &:focus,
     &:active {
-        outline: #{$underline-height} solid var(--navds-semantic-color-focus);
+        outline: #{$underline-height} solid var(--a-border-focus);
         outline-offset: -#{$underline-height};
         box-shadow: 0 0 0 0;
     }
 
     &:hover {
-        box-shadow: inset 0 -#{$underline-height} 0 0 var(--navds-global-color-gray-300);
+        box-shadow: inset 0 -#{$underline-height} 0 0 var(--a-gray-300);
     }
 }
 .lenkeActive {
-    box-shadow: inset 0 -#{$underline-height} 0 0 var(--navds-global-color-blue-400);
-    color: var(--navds-semantic-color-text);
+    box-shadow: inset 0 -#{$underline-height} 0 0 var(--a-blue-400);
+    color: var(--a-text-default);
 
     span {
         font-weight: bold;
     }
 
     &:hover {
-        box-shadow: inset 0 -#{$underline-height} 0 0 var(--navds-global-color-blue-400);
+        box-shadow: inset 0 -#{$underline-height} 0 0 var(--a-blue-400);
     }
 }
 

--- a/src/komponenter/header/header-regular/desktop/minside-meny/minside-knapper/MinsideKnapper.module.scss
+++ b/src/komponenter/header/header-regular/desktop/minside-meny/minside-knapper/MinsideKnapper.module.scss
@@ -11,7 +11,7 @@
     white-space: nowrap;
 
     &:hover {
-        box-shadow: inset 0 0 0 2px var(--navds-semantic-color-interaction-primary);
+        box-shadow: inset 0 0 0 2px var(--a-surface-action);
     }
 
     svg {
@@ -23,7 +23,7 @@
 :global(.desktop-minside-meny__knapp) {
     :global(.navds-label) {
         display: flex;
-        gap: var(--navds-spacing-2);
+        gap: var(--a-spacing-2);
     }
 }
 

--- a/src/komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/innlogget/DittNavMeny.scss
+++ b/src/komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/innlogget/DittNavMeny.scss
@@ -1,5 +1,5 @@
 .mobilDittNavMeny {
-    border-bottom: 1px solid var(--navds-global-color-gray-600);
+    border-bottom: 1px solid var(--a-gray-600);
     padding-bottom: 1rem;
     margin-bottom: 1rem;
 }

--- a/src/komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/innlogget/MobilInnloggetBruker.scss
+++ b/src/komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/innlogget/MobilInnloggetBruker.scss
@@ -8,6 +8,6 @@
     &__loggut {
         margin-top: 0.5rem;
         margin-left: -0.5rem;
-        font-weight: var(--navds-font-weight-bold);
+        font-weight: var(--a-font-weight-bold);
     }
 }

--- a/src/komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/menypunkt/MobilMenypunkt.scss
+++ b/src/komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/menypunkt/MobilMenypunkt.scss
@@ -5,8 +5,8 @@
     padding: 1rem;
     margin: 0 -1rem;
 
-    font-size: var(--navds-font-size-heading-small);
-    font-weight: var(--navds-font-weight-bold);
+    font-size: var(--a-font-size-heading-small);
+    font-weight: var(--a-font-weight-bold);
 
     & > svg {
         margin-left: auto;

--- a/src/styling-variabler.scss
+++ b/src/styling-variabler.scss
@@ -29,10 +29,10 @@ $header-height-simple-mobile: 66px;
 
 $menu-height-mobil: calc(100% - $header-height-mobil);
 
-$header-separator-farge: var(--navds-global-color-gray-300);
+$header-separator-farge: var(--a-gray-300);
 $header-separator-height: 1px;
 
-$footer-seperator-farge: var(--navds-global-color-gray-300);
+$footer-seperator-farge: var(--a-gray-300);
 $footer-seperator-height: 2px;
 
 @mixin flex-col-width-mixin($cols, $margins) {
@@ -47,9 +47,9 @@ $footer-seperator-height: 2px;
 @mixin header-knapp-focus-mixin() {
     &:focus {
         background-color: transparent;
-        color: var(--navds-global-color-blue-500);
+        color: var(--a-blue-500);
         outline: none;
-        box-shadow: 0 0 0 4px var(--navds-semantic-color-focus);
+        box-shadow: 0 0 0 4px var(--a-border-focus);
         border-radius: 4px;
         border-color: transparent;
     }


### PR DESCRIPTION
https://aksel.nav.no/designsystem/side/migrering
https://aksel.nav.no/designsystem/side/tokens-semantiske-farger

## Endringer
- Oppdatert all token-bruk til nytt format (--a prefix, nye semantiske farger)
- Oppdatert font-lasting

### Fonter
- Fonter lastes nå inn fra cdn.nav.no og må derfor legges til i CSP. (prøvde '*.cdn.nav.no' lokalt, men fikk det ikke til å fungere, kan kanskje fikses?)
- La også preload for fontlasting i `head`

#

Måler er å minske css-en som blir lastet og vil spare 70kB++ med denne endringen + den blir cachet nå. Har opprettet en [PR](https://github.com/navikt/chatbot/pull/50) for nav-chatbot også for v2, men siden den fortsatt bruker de gamle nav-frontend-* pakkene, vil det fortsatt følge med rundt 55kB font-styling frem til det er oppdatert.
