### PR TITLE
🐛 Fikset prefiksing av `navds-modal`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
             "name": "nav-dekoratoren",
             "version": "1.0.0",
             "dependencies": {
-                "@navikt/ds-css": "1.3.21",
-                "@navikt/ds-icons": "1.3.21",
-                "@navikt/ds-react": "1.3.21",
-                "@navikt/ds-tokens": "1.3.21",
+                "@navikt/ds-css": "1.5.10",
+                "@navikt/ds-icons": "1.5.10",
+                "@navikt/ds-react": "1.5.10",
+                "@navikt/ds-tokens": "1.5.10",
                 "@navikt/nav-chatbot": "2.7.4",
                 "@navikt/nav-dekoratoren-moduler": "1.7.0",
                 "@promster/express": "5.1.3",
@@ -3219,15 +3219,15 @@
             }
         },
         "node_modules/@navikt/ds-css": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/1.3.21/4ab1893d582f021e9f000f3be2ee50bbdf7a8bf4",
-            "integrity": "sha512-8TgBpXlvEf3/0QpAQWy0o28AE987+AiOGWom+aWx+BfBj+xlnbvbW25cUdCBRTj/xSqN7ziGbJZ3KGJCbAMztg==",
+            "version": "1.5.10",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/1.5.10/c36bc38c2694f6aab87bd0905c9078cc1ea2c3b2",
+            "integrity": "sha512-Y+6EIHi48GPAx/fJR5Egacr//oUpoNUhmDE7dDK9h4EumFZvqyidYv7+ZBkqFfo8uJKjSlj/51mTK0/kqFTvow==",
             "license": "MIT"
         },
         "node_modules/@navikt/ds-icons": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/1.3.21/5f6e637f73f3c8b8b6f2a7d0005b254773487b7f",
-            "integrity": "sha512-ghbUqmFR6LOB3SiZnNJHZHuVWB50RSWy052Ea+fhzIFxs2IcVR9wFpnL5PJW0c/4yjVhDu1BVGUSYVjfgqd4Sg==",
+            "version": "1.5.10",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/1.5.10/40c493b2be774d2baada7ea158a88ed7c9bd661e",
+            "integrity": "sha512-0IOEbIo+NjKEUtyRna7KMSIi950qpU73t7sazhlQzvTm2akT24mNkLn+aHpRv7dZ4pwlUPv4d80+IGk2W/pvbw==",
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^17.0.30 || ^18.0.0",
@@ -3235,13 +3235,13 @@
             }
         },
         "node_modules/@navikt/ds-react": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/1.3.21/f8fc6665b227dd0d650aff398678916aa802e66e",
-            "integrity": "sha512-s1hlLoQ05NTIhR3h+4laRsyaxaGh/RvntYWt8G5A2YVP34mWqKiw6wV4ilNmpbSVFnJ/6mvzSM2ScPTRA//Qww==",
+            "version": "1.5.10",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/1.5.10/9ddf131f98090d7576b236f4e1c30a115aa9bc8a",
+            "integrity": "sha512-PsJqkEFWTg4kxhnmYbdDX79Rl9S8jvjkzKny+j45tehVP6n0RvkYTI+29X56jZLVu5FMnNQCKg2nY7RmTTVyzw==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/react-dom-interactions": "0.9.2",
-                "@navikt/ds-icons": "^1.3.21",
+                "@navikt/ds-icons": "^1.5.10",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
                 "clsx": "^1.2.1",
@@ -3255,9 +3255,9 @@
             }
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/1.3.21/277f7434a8023cd58d2071fcd6942e0017cf9646",
-            "integrity": "sha512-VstkLAu2j43d1vRC6ZwBHBIQ/fm6HqeTHXTqEhH60SG3JOMANfpN4gTrnmZfqlSiBuiEUdnRKsp5MpWfWquVTA==",
+            "version": "1.5.10",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/1.5.10/50dff1b8975c56a8f75ed55b229d89970064085b",
+            "integrity": "sha512-JZUlaU4nStdajoIATljGE3HYv2Mf+SfcIw0T9p2zWXcQsDKmbFVc32y2w/payew6HGdgoMtxfral+rc9wMIpWw==",
             "license": "MIT"
         },
         "node_modules/@navikt/fnrvalidator": {
@@ -24861,23 +24861,23 @@
             }
         },
         "@navikt/ds-css": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/1.3.21/4ab1893d582f021e9f000f3be2ee50bbdf7a8bf4",
-            "integrity": "sha512-8TgBpXlvEf3/0QpAQWy0o28AE987+AiOGWom+aWx+BfBj+xlnbvbW25cUdCBRTj/xSqN7ziGbJZ3KGJCbAMztg=="
+            "version": "1.5.10",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/1.5.10/c36bc38c2694f6aab87bd0905c9078cc1ea2c3b2",
+            "integrity": "sha512-Y+6EIHi48GPAx/fJR5Egacr//oUpoNUhmDE7dDK9h4EumFZvqyidYv7+ZBkqFfo8uJKjSlj/51mTK0/kqFTvow=="
         },
         "@navikt/ds-icons": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/1.3.21/5f6e637f73f3c8b8b6f2a7d0005b254773487b7f",
-            "integrity": "sha512-ghbUqmFR6LOB3SiZnNJHZHuVWB50RSWy052Ea+fhzIFxs2IcVR9wFpnL5PJW0c/4yjVhDu1BVGUSYVjfgqd4Sg==",
+            "version": "1.5.10",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/1.5.10/40c493b2be774d2baada7ea158a88ed7c9bd661e",
+            "integrity": "sha512-0IOEbIo+NjKEUtyRna7KMSIi950qpU73t7sazhlQzvTm2akT24mNkLn+aHpRv7dZ4pwlUPv4d80+IGk2W/pvbw==",
             "requires": {}
         },
         "@navikt/ds-react": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/1.3.21/f8fc6665b227dd0d650aff398678916aa802e66e",
-            "integrity": "sha512-s1hlLoQ05NTIhR3h+4laRsyaxaGh/RvntYWt8G5A2YVP34mWqKiw6wV4ilNmpbSVFnJ/6mvzSM2ScPTRA//Qww==",
+            "version": "1.5.10",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/1.5.10/9ddf131f98090d7576b236f4e1c30a115aa9bc8a",
+            "integrity": "sha512-PsJqkEFWTg4kxhnmYbdDX79Rl9S8jvjkzKny+j45tehVP6n0RvkYTI+29X56jZLVu5FMnNQCKg2nY7RmTTVyzw==",
             "requires": {
                 "@floating-ui/react-dom-interactions": "0.9.2",
-                "@navikt/ds-icons": "^1.3.21",
+                "@navikt/ds-icons": "^1.5.10",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
                 "clsx": "^1.2.1",
@@ -24887,9 +24887,9 @@
             }
         },
         "@navikt/ds-tokens": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/1.3.21/277f7434a8023cd58d2071fcd6942e0017cf9646",
-            "integrity": "sha512-VstkLAu2j43d1vRC6ZwBHBIQ/fm6HqeTHXTqEhH60SG3JOMANfpN4gTrnmZfqlSiBuiEUdnRKsp5MpWfWquVTA=="
+            "version": "1.5.10",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/1.5.10/50dff1b8975c56a8f75ed55b229d89970064085b",
+            "integrity": "sha512-JZUlaU4nStdajoIATljGE3HYv2Mf+SfcIw0T9p2zWXcQsDKmbFVc32y2w/payew6HGdgoMtxfral+rc9wMIpWw=="
         },
         "@navikt/fnrvalidator": {
             "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
         "url": "https://github.com/navikt/nav-dekoratoren/issues"
     },
     "dependencies": {
-        "@navikt/ds-css": "1.3.21",
-        "@navikt/ds-icons": "1.3.21",
-        "@navikt/ds-react": "1.3.21",
-        "@navikt/ds-tokens": "1.3.21",
+        "@navikt/ds-css": "1.5.10",
+        "@navikt/ds-icons": "1.5.10",
+        "@navikt/ds-react": "1.5.10",
+        "@navikt/ds-tokens": "1.5.10",
         "@navikt/nav-chatbot": "2.7.4",
         "@navikt/nav-dekoratoren-moduler": "1.7.0",
         "@promster/express": "5.1.3",

--- a/src/komponenter/footer/Footer.tsx
+++ b/src/komponenter/footer/Footer.tsx
@@ -7,7 +7,7 @@ import FooterRegular from './footer-regular/FooterRegular';
 const Footer = () => {
     const { PARAMS } = useSelector((state: AppState) => state.environment);
     return (
-        <div id="decorator-footer-wrapper" className="decorator-wrapper">
+        <div id="decorator-footer-inner" className="decorator-wrapper">
             <footer className="sitefooter">
                 {PARAMS.SIMPLE || PARAMS.SIMPLE_FOOTER ? <SimpleFooter /> : <FooterRegular />}
             </footer>

--- a/src/komponenter/footer/Footer.tsx
+++ b/src/komponenter/footer/Footer.tsx
@@ -7,7 +7,7 @@ import FooterRegular from './footer-regular/FooterRegular';
 const Footer = () => {
     const { PARAMS } = useSelector((state: AppState) => state.environment);
     return (
-        <div className="decorator-wrapper">
+        <div id="decorator-footer-wrapper" className="decorator-wrapper">
             <footer className="sitefooter">
                 {PARAMS.SIMPLE || PARAMS.SIMPLE_FOOTER ? <SimpleFooter /> : <FooterRegular />}
             </footer>

--- a/src/komponenter/footer/common/del-skjerm-modal/DelSkjermModal.tsx
+++ b/src/komponenter/footer/common/del-skjerm-modal/DelSkjermModal.tsx
@@ -64,7 +64,7 @@ const DelSkjermModal = (props: Props) => {
         }
     };
 
-    const parent = document.getElementById('decorator-footer-wrapper');
+    const parent = document.getElementById('decorator-footer-inner');
 
     return (
         <Modal

--- a/src/komponenter/footer/common/del-skjerm-modal/DelSkjermModal.tsx
+++ b/src/komponenter/footer/common/del-skjerm-modal/DelSkjermModal.tsx
@@ -64,6 +64,8 @@ const DelSkjermModal = (props: Props) => {
         }
     };
 
+    const parent = document.getElementById('decorator-footer-wrapper');
+
     return (
         <Modal
             open={props.isOpen}
@@ -72,6 +74,7 @@ const DelSkjermModal = (props: Props) => {
             aria-label={'Skjermdeling'}
             onClose={props.onClose}
             style={{ overlay: { backgroundColor: 'rgba(50, 65, 79, 0.8)' } }}
+            parentSelector={parent ? () => parent : undefined}
         >
             <div className={style.header}>
                 <Bilde className={style.veileder} asset={veileder} altText={''} />

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,12 +18,7 @@ const prefixExclusions = [
     '.decorator-wrapper',
 ];
 
-const prefixExclusionsDsCss = [
-    '.decorator-wrapper',
-    /^\.navds-modal(:|--|$)/,
-    /^\.navds-modal__overlay/,
-    /^\.ReactModal/,
-];
+const prefixExclusionsDsCss = ['.decorator-wrapper'];
 
 const commonConfig = {
     mode: process.env.NODE_ENV || 'development',


### PR DESCRIPTION
Fikset prefiksing av `.navds-modal` klassene. 

Setter nå `parent element` som modal skal mountes i til å være under `decorator-wrapper`-klassen.