### PR TITLE
Eksponerer amplitude-klienten

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ Påkrevde CSP-direktiver for dekoratøren serveres på [https://www.nav.no/dekor
 
 [nav-dekoratoren-moduler](https://github.com/navikt/nav-dekoratoren-moduler) kan benyttes for å generere en CSP-header som er kompatibel med dekoratøren.
 
+## Amplitude-klient
+
+Logging med dekoratørens Amplitude-klient eksponeres via funksjonen `window.dekoratorenAmplitude`. Se [logEventFromApp](https://github.com/navikt/nav-dekoratoren/blob/master/src/utils/analytics/amplitude.ts) for implementasjon. <br>
+
+[nav-dekoratoren-moduler](https://github.com/navikt/nav-dekoratoren-moduler) har en hjelpefunksjon for å benytte denne.
+
 ## Oppstart via docker-compose
 
 Start **navikt/nav-dekoratoren**, **navikt/pb-nav-mocked**, **navikt/stub-oidc-provider** og **navikt/pb-oidc-provider-gui**. Oppsettet vil replikere innlogging og eksterne avhengigheter som varselinnboks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@navikt/nav-chatbot": "2.7.4",
                 "@navikt/nav-dekoratoren-moduler": "1.7.0",
                 "@promster/express": "5.1.3",
-                "amplitude-js": "7.4.4",
+                "amplitude-js": "8.21.3",
                 "bowser": "2.11.0",
                 "classnames": "2.3.2",
                 "compression": "1.7.4",
@@ -154,38 +154,51 @@
             "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
             "dev": true
         },
+        "node_modules/@amplitude/analytics-connector": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.4.6.tgz",
+            "integrity": "sha512-6jD2pOosRD4y8DT8StUCz7yTd5ZDkdOU9/AWnlWKM5qk90Mz7sdZrdZ9H7sA/L3yOJEpQOYZgQplQdWWUzyWug==",
+            "dependencies": {
+                "@amplitude/ua-parser-js": "0.7.31"
+            }
+        },
         "node_modules/@amplitude/types": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.9.2.tgz",
-            "integrity": "sha512-s+Q/O8kNfocZiyGvVdtM5T4JGPwLRZ4Q26wtEF5xJhyCtJglGMe0ixe6u/6iW9s4JHIq+LlPlUu5095pVsdtNA==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.10.2.tgz",
+            "integrity": "sha512-I8qenRI7uU6wKNb9LiZrAosSHVoNHziXouKY81CrqxH9xhVTEIJFXeuCV0hbtBr0Al/8ejnGjQRx+S2SvU/pPg==",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/@amplitude/ua-parser-js": {
-            "version": "0.7.24",
-            "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
-            "integrity": "sha512-VbQuJymJ20WEw0HtI2np7EdC3NJGUWi8+Xdbc7uk8WfMIF308T0howpzkQ3JFMN7ejnrcSM/OyNGveeE3TP3TA==",
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+            "integrity": "sha512-+z8UGRaj13Pt5NDzOnkTBy49HE2CX64jeL0ArB86HAtilpnfkPB7oqkigN7Lf2LxscMg4QhFD7mmCfedh3rqTg==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/ua-parser-js"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/faisalman"
+                }
+            ],
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/@amplitude/utils": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.9.2.tgz",
-            "integrity": "sha512-hGOIoIjmZ0pq/3b2gBrr17TaEarlR+qzFGu5npm76+scd/51F0eNvjd0vgV6WbJT1cxhyH/5Z8kihGWOU3vS3Q==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.10.2.tgz",
+            "integrity": "sha512-tVsHXu61jITEtRjB7NugQ5cVDd4QDzne8T3ifmZye7TiJeUfVRvqe44gDtf55A+7VqhDhyEIIXTA1iVcDGqlEw==",
             "dependencies": {
-                "@amplitude/types": "^1.9.2",
-                "tslib": "^1.9.3"
+                "@amplitude/types": "^1.10.2",
+                "tslib": "^2.0.0"
             },
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/@amplitude/utils/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.1.2",
@@ -4953,12 +4966,14 @@
             }
         },
         "node_modules/amplitude-js": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-7.4.4.tgz",
-            "integrity": "sha512-3Ojj1draRcXvfxi5P+Ye/6Y4roxtf1lQEjczcLDnHU9vxbPtT4fDblC9+cdJy7XmlJkGoq+KvnItlWfLuHV9GQ==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-8.21.3.tgz",
+            "integrity": "sha512-T9JsPoPWDm9sOWQrdJy+69ssYLev56993z+oP11TSjqhU9IHH45lMbWORB3YqJGE0dJw2U1qmepxkP5yOoymRA==",
             "dependencies": {
-                "@amplitude/ua-parser-js": "0.7.24",
-                "@amplitude/utils": "^1.0.5",
+                "@amplitude/analytics-connector": "^1.4.6",
+                "@amplitude/ua-parser-js": "0.7.31",
+                "@amplitude/utils": "^1.10.1",
+                "@babel/runtime": "^7.3.4",
                 "blueimp-md5": "^2.10.0",
                 "query-string": "5"
             }
@@ -22644,30 +22659,31 @@
             "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
             "dev": true
         },
+        "@amplitude/analytics-connector": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.4.6.tgz",
+            "integrity": "sha512-6jD2pOosRD4y8DT8StUCz7yTd5ZDkdOU9/AWnlWKM5qk90Mz7sdZrdZ9H7sA/L3yOJEpQOYZgQplQdWWUzyWug==",
+            "requires": {
+                "@amplitude/ua-parser-js": "0.7.31"
+            }
+        },
         "@amplitude/types": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.9.2.tgz",
-            "integrity": "sha512-s+Q/O8kNfocZiyGvVdtM5T4JGPwLRZ4Q26wtEF5xJhyCtJglGMe0ixe6u/6iW9s4JHIq+LlPlUu5095pVsdtNA=="
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.10.2.tgz",
+            "integrity": "sha512-I8qenRI7uU6wKNb9LiZrAosSHVoNHziXouKY81CrqxH9xhVTEIJFXeuCV0hbtBr0Al/8ejnGjQRx+S2SvU/pPg=="
         },
         "@amplitude/ua-parser-js": {
-            "version": "0.7.24",
-            "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
-            "integrity": "sha512-VbQuJymJ20WEw0HtI2np7EdC3NJGUWi8+Xdbc7uk8WfMIF308T0howpzkQ3JFMN7ejnrcSM/OyNGveeE3TP3TA=="
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+            "integrity": "sha512-+z8UGRaj13Pt5NDzOnkTBy49HE2CX64jeL0ArB86HAtilpnfkPB7oqkigN7Lf2LxscMg4QhFD7mmCfedh3rqTg=="
         },
         "@amplitude/utils": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.9.2.tgz",
-            "integrity": "sha512-hGOIoIjmZ0pq/3b2gBrr17TaEarlR+qzFGu5npm76+scd/51F0eNvjd0vgV6WbJT1cxhyH/5Z8kihGWOU3vS3Q==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.10.2.tgz",
+            "integrity": "sha512-tVsHXu61jITEtRjB7NugQ5cVDd4QDzne8T3ifmZye7TiJeUfVRvqe44gDtf55A+7VqhDhyEIIXTA1iVcDGqlEw==",
             "requires": {
-                "@amplitude/types": "^1.9.2",
-                "tslib": "^1.9.3"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "@amplitude/types": "^1.10.2",
+                "tslib": "^2.0.0"
             }
         },
         "@ampproject/remapping": {
@@ -26251,12 +26267,14 @@
             "requires": {}
         },
         "amplitude-js": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-7.4.4.tgz",
-            "integrity": "sha512-3Ojj1draRcXvfxi5P+Ye/6Y4roxtf1lQEjczcLDnHU9vxbPtT4fDblC9+cdJy7XmlJkGoq+KvnItlWfLuHV9GQ==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-8.21.3.tgz",
+            "integrity": "sha512-T9JsPoPWDm9sOWQrdJy+69ssYLev56993z+oP11TSjqhU9IHH45lMbWORB3YqJGE0dJw2U1qmepxkP5yOoymRA==",
             "requires": {
-                "@amplitude/ua-parser-js": "0.7.24",
-                "@amplitude/utils": "^1.0.5",
+                "@amplitude/analytics-connector": "^1.4.6",
+                "@amplitude/ua-parser-js": "0.7.31",
+                "@amplitude/utils": "^1.10.1",
+                "@babel/runtime": "^7.3.4",
                 "blueimp-md5": "^2.10.0",
                 "query-string": "5"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
                 "@babel/preset-react": "7.18.6",
                 "@testing-library/jest-dom": "5.16.5",
                 "@testing-library/react": "13.4.0",
-                "@types/amplitude-js": "7.0.1",
+                "@types/amplitude-js": "8.16.2",
                 "@types/classnames": "2.3.1",
                 "@types/compression": "1.7.2",
                 "@types/express": "4.17.14",
@@ -3959,9 +3959,9 @@
             }
         },
         "node_modules/@types/amplitude-js": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@types/amplitude-js/-/amplitude-js-7.0.1.tgz",
-            "integrity": "sha512-xrmhX39GoSBIuOOPWYL5uvVLn6a5Cvea0wb6SkJNW9+2w5GCK6hT0vvMaH1GaaeSqvb1QFjHNsEgXuyQqML0sw==",
+            "version": "8.16.2",
+            "resolved": "https://registry.npmjs.org/@types/amplitude-js/-/amplitude-js-8.16.2.tgz",
+            "integrity": "sha512-a+tb/CEQOlrHRvEvAuYNOcoUy1POERANnAhfKgiTmsy0eACj3eukGP0ucA9t115QOPzVUhbnUfZqtyHp99IZyA==",
             "dev": true
         },
         "node_modules/@types/aria-query": {
@@ -25399,9 +25399,9 @@
             "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
         },
         "@types/amplitude-js": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@types/amplitude-js/-/amplitude-js-7.0.1.tgz",
-            "integrity": "sha512-xrmhX39GoSBIuOOPWYL5uvVLn6a5Cvea0wb6SkJNW9+2w5GCK6hT0vvMaH1GaaeSqvb1QFjHNsEgXuyQqML0sw==",
+            "version": "8.16.2",
+            "resolved": "https://registry.npmjs.org/@types/amplitude-js/-/amplitude-js-8.16.2.tgz",
+            "integrity": "sha512-a+tb/CEQOlrHRvEvAuYNOcoUy1POERANnAhfKgiTmsy0eACj3eukGP0ucA9t115QOPzVUhbnUfZqtyHp99IZyA==",
             "dev": true
         },
         "@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@navikt/nav-chatbot": "2.7.4",
         "@navikt/nav-dekoratoren-moduler": "1.7.0",
         "@promster/express": "5.1.3",
-        "amplitude-js": "7.4.4",
+        "amplitude-js": "8.21.3",
         "bowser": "2.11.0",
         "classnames": "2.3.2",
         "compression": "1.7.4",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "@babel/preset-react": "7.18.6",
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "13.4.0",
-        "@types/amplitude-js": "7.0.1",
+        "@types/amplitude-js": "8.16.2",
         "@types/classnames": "2.3.1",
         "@types/compression": "1.7.2",
         "@types/express": "4.17.14",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,7 +4,15 @@ declare global {
     interface Window {
         TA: any;
         dataLayer: any;
-        dekoratorenAmplitude: (eventName: string, appName: string, eventData?: EventData) => Promise<any>;
+        dekoratorenAmplitude: ({
+            appName,
+            eventName,
+            eventData,
+        }?: {
+            appName: string;
+            eventName: string;
+            eventData?: EventData;
+        }) => Promise<any>;
     }
 
     namespace NodeJS {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,9 +1,12 @@
 declare global {
     let TA: any;
+
     interface Window {
         TA: any;
         dataLayer: any;
+        dekoratorenAmplitude: (eventName: string, appName: string, eventData?: EventData) => Promise<any>;
     }
+
     namespace NodeJS {
         interface ProcessEnv {
             ENV: 'prod' | 'dev' | 'localhost';

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,11 +5,11 @@ declare global {
         TA: any;
         dataLayer: any;
         dekoratorenAmplitude: ({
-            appName,
+            origin,
             eventName,
             eventData,
         }?: {
-            appName: string;
+            origin: string;
             eventName: string;
             eventData?: EventData;
         }) => Promise<any>;

--- a/src/utils/analytics/amplitude.ts
+++ b/src/utils/analytics/amplitude.ts
@@ -68,11 +68,7 @@ export const logPageView = (params: Params, authState: InnloggingsstatusState) =
 };
 
 export const logAmplitudeEvent = (eventName: string, eventData: EventData = {}) => {
-    return new Promise(function (resolve, reject) {
-        if (!amplitude) {
-            reject('Amplitude is not initialized!');
-        }
-
+    return new Promise(function (resolve) {
         eventData.platform = window.location.toString();
         eventData.origin = 'dekoratøren';
         eventData.originVersion = 'unknown';

--- a/src/utils/analytics/amplitude.ts
+++ b/src/utils/analytics/amplitude.ts
@@ -24,8 +24,33 @@ export const initAmplitude = () => {
     window.dekoratorenAmplitude = logEventFromApp;
 };
 
-const logEventFromApp = (eventName: string, appName: string, eventData: EventData = {}) => {
-    return logAmplitudeEvent(eventName, { ...eventData, app: appName });
+const logEventFromApp = (params?: {
+    appName: unknown | string;
+    eventName: unknown | string;
+    eventData?: unknown | EventData;
+}): Promise<any> => {
+    try {
+        if (!params || params.constructor !== Object) {
+            return Promise.reject(
+                'Argument must be an object of type {appName: string, eventName: string, eventData?: Record<string, any>}'
+            );
+        }
+
+        const { appName, eventName, eventData = {} } = params;
+        if (!eventName || typeof eventName !== 'string') {
+            return Promise.reject('Parameter "eventName" must be a string');
+        }
+        if (!appName || typeof appName !== 'string') {
+            return Promise.reject('Parameter "appName" must be a string');
+        }
+        if (!eventData || eventData.constructor !== Object) {
+            return Promise.reject('Parameter "eventData" must be a plain object');
+        }
+
+        return logAmplitudeEvent(eventName, { ...eventData, app: appName });
+    } catch (e) {
+        return Promise.reject(`Unexpected Amplitude error: ${e}`);
+    }
 };
 
 export const logPageView = (params: Params, authState: InnloggingsstatusState) => {

--- a/src/utils/analytics/amplitude.ts
+++ b/src/utils/analytics/amplitude.ts
@@ -25,29 +25,29 @@ export const initAmplitude = () => {
 };
 
 const logEventFromApp = (params?: {
-    appName: unknown | string;
+    origin: unknown | string;
     eventName: unknown | string;
     eventData?: unknown | EventData;
 }): Promise<any> => {
     try {
         if (!params || params.constructor !== Object) {
             return Promise.reject(
-                'Argument must be an object of type {appName: string, eventName: string, eventData?: Record<string, any>}'
+                'Argument must be an object of type {origin: string, eventName: string, eventData?: Record<string, any>}'
             );
         }
 
-        const { appName, eventName, eventData = {} } = params;
+        const { origin, eventName, eventData = {} } = params;
         if (!eventName || typeof eventName !== 'string') {
             return Promise.reject('Parameter "eventName" must be a string');
         }
-        if (!appName || typeof appName !== 'string') {
-            return Promise.reject('Parameter "appName" must be a string');
+        if (!origin || typeof origin !== 'string') {
+            return Promise.reject('Parameter "origin" must be a string');
         }
         if (!eventData || eventData.constructor !== Object) {
             return Promise.reject('Parameter "eventData" must be a plain object');
         }
 
-        return logAmplitudeEvent(eventName, { ...eventData, app: appName });
+        return logAmplitudeEvent(eventName, eventData, origin);
     } catch (e) {
         return Promise.reject(`Unexpected Amplitude error: ${e}`);
     }
@@ -67,12 +67,17 @@ export const logPageView = (params: Params, authState: InnloggingsstatusState) =
     });
 };
 
-export const logAmplitudeEvent = (eventName: string, eventData: EventData = {}) => {
-    return new Promise(function (resolve) {
-        eventData.platform = window.location.toString();
-        eventData.origin = 'dekoratøren';
-        eventData.originVersion = 'unknown';
-
-        amplitude.getInstance().logEvent(eventName, eventData, resolve);
+export const logAmplitudeEvent = (eventName: string, eventData: EventData = {}, origin = 'dekoratøren') => {
+    return new Promise((resolve) => {
+        amplitude.getInstance().logEvent(
+            eventName,
+            {
+                ...eventData,
+                platform: window.location.toString(),
+                origin,
+                originVersion: eventData.originVersion || 'unknown',
+            },
+            resolve
+        );
     });
 };


### PR DESCRIPTION
Definerer en funksjon på `window`-objektet som kaller dekoratørens instans av amplitude, slik at appene kan benytte denne. Slipper dermed at appene trenger sin egen amplitude-klient.

Oppdatere også amplitude-js. Nyeste versjon krasjer ikke ved server-side import. 🥳 