### PR TITLE
Gjeninnfører utvalg av TA-surveys

### DIFF
--- a/src/utils/analytics/task-analytics/ta-cookies.ts
+++ b/src/utils/analytics/task-analytics/ta-cookies.ts
@@ -33,7 +33,7 @@ export const taskAnalyticsSetSelected = (surveyId: string) => {
     setCookie({ ...currentState, selected: { id: surveyId, ts: Date.now() } });
 };
 
-export const taskAnalyticsGetSelectedSurvey = () => {
+export const taskAnalyticsGetSelectedSurveyId = () => {
     return taskAnalyticsGetState().selected?.id;
 };
 

--- a/src/utils/analytics/task-analytics/ta-cookies.ts
+++ b/src/utils/analytics/task-analytics/ta-cookies.ts
@@ -1,13 +1,13 @@
 import Cookies from 'js-cookie';
 
 /*
- * We keep the state of survey selection for a user in a cookie. When a survey has matched for a user
- * and been part of the selection draw, we should not attempt to show this to the user again for
- * <expireTimeDays> days. We also don't want to show any surveys for 30 days if a survey is selected
- * in a draw
+ * We keep the state of survey selection for the user in a cookie. When a survey has matched for a user
+ * and has been part of the selection draw, we should not attempt to draw this for this user again for
+ * <expireTimeDays> days. Also, if a survey is selected in a draw, we only want to show this survey for
+ * the next <expireTimeDays> days
  * */
 
-type TaskAnalyticsState = { selected?: { id: string; ts: number }; matched: Record<string, number> };
+type TaskAnalyticsState = { selected?: { id: string; ts: number }; matched?: Record<string, number> };
 
 const cookieName = 'ta-dekoratoren-v2';
 
@@ -34,17 +34,11 @@ export const taskAnalyticsSetSelected = (surveyId: string) => {
 };
 
 export const taskAnalyticsGetSelectedSurvey = () => {
-    const currentState = taskAnalyticsGetState();
-    return currentState['selected']?.id;
+    return taskAnalyticsGetState().selected?.id;
 };
 
 export const taskAnalyticsRefreshState = () => {
-    const prevState = taskAnalyticsGetState();
-    if (!prevState) {
-        return;
-    }
-
-    const { matched, selected } = prevState;
+    const { matched, selected } = taskAnalyticsGetState();
 
     const now = Date.now();
 
@@ -58,7 +52,7 @@ export const taskAnalyticsRefreshState = () => {
 
               return { ...acc, [key]: timestamp };
           }, {})
-        : {};
+        : undefined;
 
     setCookie({ matched: freshMatched, selected: freshSelected });
 };

--- a/src/utils/analytics/task-analytics/ta-matching.ts
+++ b/src/utils/analytics/task-analytics/ta-matching.ts
@@ -39,7 +39,11 @@ const isMatchingUrls = (urls: TaskAnalyticsUrlRule[]) => {
     return !(isExcluded || isMatched === false);
 };
 
-const isMatchingSurvey = (survey: TaskAnalyticsSurveyConfig, currentLanguage: Locale, currentAudience: MenuValue) => {
+export const taskAnalyticsIsMatchingSurvey = (
+    survey: TaskAnalyticsSurveyConfig,
+    currentLanguage: Locale,
+    currentAudience: MenuValue
+) => {
     const { urls, audience, language } = survey;
 
     if (urls && !isMatchingUrls(urls)) {
@@ -75,7 +79,7 @@ export const taskAnalyticsGetMatchingSurveys = (
             return false;
         }
 
-        const isMatching = isMatchingSurvey(survey, currentLanguage, currentAudience);
+        const isMatching = taskAnalyticsIsMatchingSurvey(survey, currentLanguage, currentAudience);
         if (!isMatching) {
             return false;
         }

--- a/src/utils/analytics/task-analytics/ta-matching.ts
+++ b/src/utils/analytics/task-analytics/ta-matching.ts
@@ -62,7 +62,7 @@ export const taskAnalyticsGetMatchingSurveys = (
     currentLanguage: Locale,
     currentAudience: MenuValue
 ) => {
-    const { matched = {} } = taskAnalyticsGetState();
+    const { matched: prevMatched = {} } = taskAnalyticsGetState();
 
     const matchingSurveys = surveys.filter((survey) => {
         const { id } = survey;
@@ -71,7 +71,7 @@ export const taskAnalyticsGetMatchingSurveys = (
             return false;
         }
 
-        if (matched[id]) {
+        if (prevMatched[id]) {
             return false;
         }
 
@@ -85,9 +85,5 @@ export const taskAnalyticsGetMatchingSurveys = (
         return true;
     });
 
-    if (matchingSurveys.length === 0) {
-        return null;
-    }
-
-    return matchingSurveys;
+    return matchingSurveys.length === 0 ? null : matchingSurveys;
 };

--- a/src/utils/analytics/task-analytics/ta-matching.ts
+++ b/src/utils/analytics/task-analytics/ta-matching.ts
@@ -62,7 +62,7 @@ export const taskAnalyticsGetMatchingSurveys = (
     currentLanguage: Locale,
     currentAudience: MenuValue
 ) => {
-    const taState = taskAnalyticsGetState();
+    const { matched = {} } = taskAnalyticsGetState();
 
     const matchingSurveys = surveys.filter((survey) => {
         const { id } = survey;
@@ -71,9 +71,9 @@ export const taskAnalyticsGetMatchingSurveys = (
             return false;
         }
 
-        // if (taState[id]) {
-        //     return false;
-        // }
+        if (matched[id]) {
+            return false;
+        }
 
         const isMatching = isMatchingSurvey(survey, currentLanguage, currentAudience);
         if (!isMatching) {

--- a/src/utils/analytics/task-analytics/ta-matching.ts
+++ b/src/utils/analytics/task-analytics/ta-matching.ts
@@ -1,7 +1,15 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 import { Locale } from '../../../store/reducers/language-duck';
 import { MenuValue } from '../../meny-storage-utils';
 import { TaskAnalyticsSurveyConfig, TaskAnalyticsUrlRule } from './ta';
 import { taskAnalyticsGetState, taskAnalyticsSetSurveyMatched } from './ta-cookies';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const norwayTz = 'Europe/Oslo';
 
 type Audience = Required<TaskAnalyticsSurveyConfig>['audience'][number];
 type Language = Required<TaskAnalyticsSurveyConfig>['language'][number];
@@ -59,9 +67,9 @@ const isMatchingDuration = (duration: Duration) => {
     }
 
     const { start, end } = duration;
-    const now = Date.now();
+    const now = dayjs().tz(norwayTz);
 
-    return (!start || now > Date.parse(start)) && (!end || now < Date.parse(end));
+    return (!start || now.isAfter(dayjs.tz(start, norwayTz))) && (!end || now.isBefore(dayjs.tz(end, norwayTz)));
 };
 
 export const taskAnalyticsIsMatchingSurvey = (

--- a/src/utils/analytics/task-analytics/ta.ts
+++ b/src/utils/analytics/task-analytics/ta.ts
@@ -54,7 +54,7 @@ const findAndStartSurvey = (surveys: TaskAnalyticsSurveyConfig[], state: AppStat
     const { status: currentAudience } = arbeidsflate;
     const { language: currentLanguage } = language;
 
-    // If the user was previously selected for a survey, start it
+    // If a survey was previously selected for the user, try to start it
     const selectedSurveyId = taskAnalyticsGetSelectedSurveyId();
     if (selectedSurveyId) {
         startSurveyIfMatching(selectedSurveyId, surveys, currentLanguage, currentAudience);

--- a/src/utils/analytics/task-analytics/ta.ts
+++ b/src/utils/analytics/task-analytics/ta.ts
@@ -14,6 +14,10 @@ export type TaskAnalyticsUrlRule = {
 export type TaskAnalyticsSurveyConfig = {
     id: string;
     selection?: number;
+    duration?: {
+        start?: string;
+        end?: string;
+    };
     urls?: TaskAnalyticsUrlRule[];
     audience?: MenuValue[];
     language?: Locale[];


### PR DESCRIPTION
...med noen tweaks på logikken. Dersom en undersøkelse blir trukket ut for brukeren, vil denne nå startes de neste 30 dager, og ikke kun ved besøket der trekket ble utført. TA skal selv holde styr på om brukeren faktisk har svart på eller krysset vekk undersøkelsen, og hindre at den maser unødvendig mye. 😄

Støtter også start/slutt-tid på undersøkelser