### PR TITLE
Korekt bruk av ARIA i arbeidsflatemenyen

### DIFF
--- a/src/komponenter/header/header-regular/desktop/arbeidsflatemeny/Arbeidsflatemeny.tsx
+++ b/src/komponenter/header/header-regular/desktop/arbeidsflatemeny/Arbeidsflatemeny.tsx
@@ -37,11 +37,12 @@ const Arbeidsflatemeny = () => {
                 {arbeidsflateLenker(XP_BASE_URL).map((lenke, index) => {
                     return (
                         <li
-                            aria-current={arbeidsflate === lenke.key ? 'page' : 'false'}
+                            role="none"
                             className={style.listeElement}
                             key={lenke.key}
                         >
                             <LenkeMedSporing
+                                aria-current={arbeidsflate === lenke.key ? 'page' : 'false'}
                                 role="menuitem"
                                 classNameOverride={classNames(
                                     style.lenke,


### PR DESCRIPTION
li skal ha role="none" og det er lenkene med role="menuitem" under som skal ha aria-attributter
https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-navigation/