### PR TITLE
Feature toggle for boost script

### DIFF
--- a/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
@@ -12,6 +12,7 @@ import style from './ChatbotWrapper.module.scss';
 const stateSelector = (state: AppState) => ({
     chatbotParamEnabled: state.environment.PARAMS.CHATBOT,
     chatbotParamVisible: state.environment.PARAMS.CHATBOT_VISIBLE,
+    featureToggles: state.featureToggles,
     context: state.arbeidsflate.status,
     env: state.environment.ENV,
 });
@@ -33,6 +34,7 @@ export const ChatbotWrapper = () => {
     const [boost, setBoost] = useState<BoostObject | undefined>();
     const [bufferLoad, setBufferLoad] = useState<Boolean>(false);
     const [scriptLoaded, setScriptLoaded] = useState<Boolean>(false);
+    const currentFeatureToggles = useSelector(stateSelector).featureToggles;
 
     const isProduction = env === 'prod';
     const boostApiUrlBase = isProduction ? boostApiUrlBaseProduction : boostApiUrlBaseTest;
@@ -69,7 +71,9 @@ export const ChatbotWrapper = () => {
     useEffect(() => {
         const hasConversation = cookies[conversationCookieName];
         const isVisible = hasConversation || chatbotParamVisible;
-        if (!isVisible) {
+        const isScriptEnabled = currentFeatureToggles['dekoratoren.chatbotscript'];
+
+        if (!isVisible || !isScriptEnabled) {
             return;
         }
 

--- a/src/komponenter/header/Header.tsx
+++ b/src/komponenter/header/Header.tsx
@@ -70,6 +70,8 @@ export const Header = () => {
 
     useOnPushStateHandlers();
 
+    console.log(currentFeatureToggles);
+
     // Map prod to dev urls with url-lookup-table
     const setUrlLookupTableUrls = () => {
         const anchors = Array.prototype.slice.call(document.getElementsByTagName('a'));

--- a/src/komponenter/header/Header.tsx
+++ b/src/komponenter/header/Header.tsx
@@ -70,8 +70,6 @@ export const Header = () => {
 
     useOnPushStateHandlers();
 
-    console.log(currentFeatureToggles);
-
     // Map prod to dev urls with url-lookup-table
     const setUrlLookupTableUrls = () => {
         const anchors = Array.prototype.slice.call(document.getElementsByTagName('a'));

--- a/src/store/reducers/feature-toggles-duck.ts
+++ b/src/store/reducers/feature-toggles-duck.ts
@@ -12,13 +12,11 @@ export interface FeatureToggles {
 // }
 export const initialState: FeatureToggles = {
     'dekoratoren.skjermdeling': false,
+    'dekoratoren.chatbotscript': false,
 };
 // Defined toggles will be fetched from unleash on runtime
 
-export const reducer = (
-    state: FeatureToggles = initialState,
-    action: Handling
-): FeatureToggles => {
+export const reducer = (state: FeatureToggles = initialState, action: Handling): FeatureToggles => {
     switch (action.type) {
         case ActionType.SETT_FEATURE_TOGGLES: {
             return { ...state, ...action.data };


### PR DESCRIPTION
Påfølgende PR fra branchen `newChatbotFrontend`. Siden scripts lastes direkte fra boost uten at vi har kontroll på versjonering, så trenger vi en mekanisme for å raskt kunne disable innlasting av scriptet dersom det skulle oppstå type feil som ødelegger annen funksjonalitet i applikasjonen som konsumerer dekoratøren.

Merk:
Denne erstatter ikke den generelle rutinen for å skru på varsel-melding om chatbot-problemer (ref innholdsstrategi). Det er kun en failsafe som gir oss mulighet til å slå av chatbot på få minutter mens vi legger opp et redaksjonelt varsel.

Avhengigheter:
Avhenger av branchen `newChatbotFrontend`.