### PR TITLE
Tar vekk logging av søkeord og destinasjon til Amplitude

### DIFF
--- a/src/komponenter/header/header-regular/common/sok/sok-innhold/SokResultater.tsx
+++ b/src/komponenter/header/header-regular/common/sok/sok-innhold/SokResultater.tsx
@@ -67,8 +67,8 @@ export const SokResultater = (props: Props) => {
                                     onClick={() => {
                                         dispatch(lukkAlleDropdowns());
                                         logAmplitudeEvent('resultat-klikk', {
-                                            destinasjon: item.href,
-                                            sokeord: writtenInput.toLowerCase(),
+                                            destinasjon: '[redacted]',
+                                            sokeord: '[redacted]',
                                             treffnr: index + 1,
                                         });
                                     }}

--- a/src/utils/analytics/analytics.ts
+++ b/src/utils/analytics/analytics.ts
@@ -31,7 +31,7 @@ export const analyticsEvent = (props: AnalyticsEventArgs) => {
 
     logAmplitudeEvent(eventName || 'navigere', {
         destinasjon: destination || label,
-        søkeord: eventName === 'søk' ? label : undefined,
+        søkeord: eventName === 'søk' ? '[redacted]' : undefined,
         lenketekst: actionFinal,
         kategori: category,
         komponent: komponent || action,


### PR DESCRIPTION
Pålegg fra ResearchOps, fordi Amplitude ikke kan garantere lagring kun i EU.

Testing
Har testet lokalt
