### PR TITLE
forenklet styling webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,16 +10,7 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 const analyzeClientBundle = !!process.env.ANALYZE;
 
-const prefixExclusions = [
-    'body',
-    'body.no-scroll-mobil',
-    '.siteheader',
-    '.sitefooter',
-    /\b(\w*decorator-dummy-app\w*)\b/,
-    '#nav-chatbot',
-    ':root',
-    '.decorator-wrapper',
-];
+const prefixExclusions = ['body', 'body.no-scroll-mobil', '.siteheader', '.sitefooter', '.decorator-wrapper'];
 
 const commonConfig = {
     mode: process.env.NODE_ENV || 'development',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,8 +21,6 @@ const prefixExclusions = [
     '.decorator-wrapper',
 ];
 
-const prefixExclusionsDsCss = ['.decorator-wrapper'];
-
 const commonConfig = {
     mode: process.env.NODE_ENV || 'development',
     devtool: 'source-map',
@@ -162,34 +160,11 @@ const commonConfig = {
                                 plugins: [
                                     modifySelectors({
                                         enabled: true,
-                                        replace: [{ match: /^(:root|html|body)$/, with: '.decorator-wrapper' }],
+                                        replace: [{ match: /^(:root|:host|html|body)$/, with: '.decorator-wrapper' }],
                                     }),
                                     prefixer({
                                         prefix: '.decorator-wrapper',
-                                        exclude: prefixExclusionsDsCss,
-                                    }),
-                                    autoprefixer({}),
-                                ],
-                            },
-                        },
-                    },
-                ],
-            },
-            {
-                test: /\.(less|css)$/,
-                exclude: /@navikt(\\|\/)ds-css/,
-                use: [
-                    MiniCssExtractPlugin.loader,
-                    'css-loader',
-                    {
-                        loader: 'postcss-loader',
-                        options: {
-                            postcssOptions: {
-                                ident: 'postcss',
-                                plugins: [
-                                    prefixer({
-                                        prefix: '.decorator-wrapper',
-                                        exclude: prefixExclusions,
+                                        exclude: ['.decorator-wrapper'],
                                     }),
                                     autoprefixer({}),
                                 ],


### PR DESCRIPTION
Eneste faktiske endring i output til client.css er at `.decorator-wrapper, .decorator-wrapper :host` blir `.decorator-wrapper`, og det tror jeg ikke har noen praktiske konsekvenser. Ellers er det bare litt opprydding i config.