### PR TITLE
Fjerner role=menubar fra arbeidsflatemeny

### DIFF
--- a/src/komponenter/header/header-regular/desktop/arbeidsflatemeny/Arbeidsflatemeny.tsx
+++ b/src/komponenter/header/header-regular/desktop/arbeidsflatemeny/Arbeidsflatemeny.tsx
@@ -33,10 +33,10 @@ const Arbeidsflatemeny = () => {
 
     return (
         <div className={'arbeidsflate'} id={'arbeidsflate'}>
-            <ul className={style.toppListeRad} aria-label="Velg brukergruppe" role="menubar">
+            <ul className={style.toppListeRad} aria-label="Velg brukergruppe">
                 {arbeidsflateLenker(XP_BASE_URL).map((lenke, index) => {
                     return (
-                        <li role="none" className={style.listeElement} key={lenke.key}>
+                        <li className={style.listeElement} key={lenke.key}>
                             <LenkeMedSporing
                                 aria-current={arbeidsflate === lenke.key ? 'page' : 'false'}
                                 role="menuitem"


### PR DESCRIPTION
Skal bare brukes ved  fullverdige applikasjonsmenyer

## Testing
Har testet selv lokalt
