### PR TITLE
Bedre typing for tekstinnhold

### DIFF
--- a/src/komponenter/common/arbeidsflate-lenker/arbeidsflate-lenker.ts
+++ b/src/komponenter/common/arbeidsflate-lenker/arbeidsflate-lenker.ts
@@ -1,9 +1,10 @@
+import { LangKey } from 'tekster/ledetekster';
 import { MenuValue } from 'utils/meny-storage-utils';
 
 export interface ArbeidsflateLenke {
     url: string;
-    lenkeTekstId: string;
-    stikkordId: string;
+    lenkeTekstId: LangKey;
+    stikkordId: LangKey;
     key: MenuValue;
 }
 
@@ -16,8 +17,8 @@ export const arbeidsflateLenker = (XP_BASE_URL: string): ArbeidsflateLenke[] => 
 export const personContextLenke = (XP_BASE_URL: string) => {
     return {
         url: `${XP_BASE_URL}`,
-        lenkeTekstId: 'rolle-privatperson',
-        stikkordId: 'meny-bunnlenke-minside-stikkord',
+        lenkeTekstId: 'rolle-privatperson' as const,
+        stikkordId: 'meny-bunnlenke-minside-stikkord' as const,
         key: MenuValue.PRIVATPERSON,
     };
 };
@@ -25,8 +26,8 @@ export const personContextLenke = (XP_BASE_URL: string) => {
 export const arbeidsgiverContextLenke = (XP_BASE_URL: string) => {
     return {
         url: `${XP_BASE_URL}/no/bedrift`,
-        lenkeTekstId: 'rolle-arbeidsgiver',
-        stikkordId: 'meny-bunnlenke-arbeidsgiver-stikkord',
+        lenkeTekstId: 'rolle-arbeidsgiver' as const,
+        stikkordId: 'meny-bunnlenke-arbeidsgiver-stikkord' as const,
         key: MenuValue.ARBEIDSGIVER,
     };
 };
@@ -34,8 +35,8 @@ export const arbeidsgiverContextLenke = (XP_BASE_URL: string) => {
 export const samarbeidspartnerContextLenke = (XP_BASE_URL: string) => {
     return {
         url: `${XP_BASE_URL}/no/samarbeidspartner`,
-        lenkeTekstId: 'rolle-samarbeidspartner',
-        stikkordId: 'meny-bunnlenke-samarbeidspartner-stikkord',
+        lenkeTekstId: 'rolle-samarbeidspartner' as const,
+        stikkordId: 'meny-bunnlenke-samarbeidspartner-stikkord' as const,
         key: MenuValue.SAMARBEIDSPARTNER,
     };
 };

--- a/src/komponenter/common/arbeidsflate-lenker/arbeidsflate-lenker.ts
+++ b/src/komponenter/common/arbeidsflate-lenker/arbeidsflate-lenker.ts
@@ -14,29 +14,29 @@ export const arbeidsflateLenker = (XP_BASE_URL: string): ArbeidsflateLenke[] => 
     samarbeidspartnerContextLenke(XP_BASE_URL),
 ];
 
-export const personContextLenke = (XP_BASE_URL: string) => {
+export const personContextLenke = (XP_BASE_URL: string): ArbeidsflateLenke => {
     return {
         url: `${XP_BASE_URL}`,
-        lenkeTekstId: 'rolle-privatperson' as const,
-        stikkordId: 'meny-bunnlenke-minside-stikkord' as const,
+        lenkeTekstId: 'rolle-privatperson',
+        stikkordId: 'meny-bunnlenke-minside-stikkord',
         key: MenuValue.PRIVATPERSON,
     };
 };
 
-export const arbeidsgiverContextLenke = (XP_BASE_URL: string) => {
+export const arbeidsgiverContextLenke = (XP_BASE_URL: string): ArbeidsflateLenke => {
     return {
         url: `${XP_BASE_URL}/no/bedrift`,
-        lenkeTekstId: 'rolle-arbeidsgiver' as const,
-        stikkordId: 'meny-bunnlenke-arbeidsgiver-stikkord' as const,
+        lenkeTekstId: 'rolle-arbeidsgiver',
+        stikkordId: 'meny-bunnlenke-arbeidsgiver-stikkord',
         key: MenuValue.ARBEIDSGIVER,
     };
 };
 
-export const samarbeidspartnerContextLenke = (XP_BASE_URL: string) => {
+export const samarbeidspartnerContextLenke = (XP_BASE_URL: string): ArbeidsflateLenke => {
     return {
         url: `${XP_BASE_URL}/no/samarbeidspartner`,
-        lenkeTekstId: 'rolle-samarbeidspartner' as const,
-        stikkordId: 'meny-bunnlenke-samarbeidspartner-stikkord' as const,
+        lenkeTekstId: 'rolle-samarbeidspartner',
+        stikkordId: 'meny-bunnlenke-samarbeidspartner-stikkord',
         key: MenuValue.SAMARBEIDSPARTNER,
     };
 };

--- a/src/komponenter/common/arbeidsflate-lenker/hovedmeny-arbeidsflate-lenker.ts
+++ b/src/komponenter/common/arbeidsflate-lenker/hovedmeny-arbeidsflate-lenker.ts
@@ -1,11 +1,12 @@
 import { MenuValue } from 'utils/meny-storage-utils';
 import { arbeidsgiverContextLenke, personContextLenke, samarbeidspartnerContextLenke } from './arbeidsflate-lenker';
 import { Environment } from 'store/reducers/environment-duck';
+import { LangKey } from 'tekster/ledetekster';
 
 export type ArbeidsflateLenkeData = {
     url: string;
-    lenkeTekstId: string;
-    stikkordId: string;
+    lenkeTekstId: LangKey;
+    stikkordId: LangKey;
     key: MenuValue;
 };
 

--- a/src/komponenter/footer/common/del-skjerm-modal/DelSkjermModal.tsx
+++ b/src/komponenter/footer/common/del-skjerm-modal/DelSkjermModal.tsx
@@ -5,6 +5,7 @@ import { AppState } from 'store/reducers';
 import Tekst, { finnTekst } from 'tekster/finn-tekst';
 import { Bilde } from 'komponenter/common/bilde/Bilde';
 import style from './DelSkjermModal.module.scss';
+import { LangKey } from 'tekster/ledetekster';
 
 const veileder = require('ikoner/del-skjerm/Veileder.svg');
 interface Props {
@@ -92,7 +93,7 @@ const DelSkjermModal = (props: Props) => {
                             {[...Array(3)].map((_, i) => (
                                 <li key={i}>
                                     <BodyLong>
-                                        <Tekst id={`delskjerm-modal-hjelpetekst-${i}`} />
+                                        <Tekst id={`delskjerm-modal-hjelpetekst-${i}` as LangKey} />
                                     </BodyLong>
                                 </li>
                             ))}

--- a/src/komponenter/header/header-regular/common/meny-knapp/MenylinjeKnapp.tsx
+++ b/src/komponenter/header/header-regular/common/meny-knapp/MenylinjeKnapp.tsx
@@ -3,9 +3,10 @@ import BEMHelper from 'utils/bem';
 import Tekst from 'tekster/finn-tekst';
 import { Button } from '@navikt/ds-react';
 import style from './MenylinjeKnapp.module.scss';
+import { LangKey } from 'tekster/ledetekster';
 
 interface Props {
-    tekstId?: string;
+    tekstId?: LangKey;
     onClick: () => void;
     isOpen: boolean;
     classname: string;

--- a/src/komponenter/header/header-regular/common/spinner/Spinner.tsx
+++ b/src/komponenter/header/header-regular/common/spinner/Spinner.tsx
@@ -2,9 +2,10 @@ import React, { useId } from 'react';
 import Tekst from 'tekster/finn-tekst';
 import { BodyShort, Loader } from '@navikt/ds-react';
 import style from './Spinner.module.scss';
+import { LangKey } from 'tekster/ledetekster';
 
 type Props = {
-    tekstId?: string;
+    tekstId?: LangKey;
 };
 
 const Spinner = ({ tekstId }: Props) => {

--- a/src/komponenter/header/header-regular/desktop/hovedmeny/topp-seksjon/Toppseksjon.tsx
+++ b/src/komponenter/header/header-regular/desktop/hovedmeny/topp-seksjon/Toppseksjon.tsx
@@ -14,6 +14,7 @@ import { useCookies } from 'react-cookie';
 import { MenuValue } from '../../../../../../utils/meny-storage-utils';
 
 import style from './Toppseksjon.module.scss';
+import { LangKey } from 'tekster/ledetekster';
 
 export const Toppseksjon = () => {
     const dispatch = useDispatch();
@@ -29,7 +30,7 @@ export const Toppseksjon = () => {
                     id={
                         arbeidsflate === MenuValue.PRIVATPERSON
                             ? 'how-can-we-help'
-                            : `rolle-${arbeidsflate.toLowerCase()}`
+                            : `rolle-${arbeidsflate.toLowerCase()}` as LangKey
                     }
                 />
             </Heading>

--- a/src/komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/header/MobilHovedmenyHeader.tsx
+++ b/src/komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/header/MobilHovedmenyHeader.tsx
@@ -8,6 +8,7 @@ import Tekst from 'tekster/finn-tekst';
 import { AnalyticsCategory } from 'utils/analytics/analytics';
 
 import 'komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/header/MobilHovedmenyHeader.scss';
+import { LangKey } from 'tekster/ledetekster';
 
 const stateSelector = (state: AppState) => ({
     arbeidsflate: state.arbeidsflate.status,
@@ -24,7 +25,7 @@ export const MobilHovedmenyHeader = () => {
     return (
         <div className={'mobilMenyHeader'}>
             <Heading level="2" size="small">
-                <Tekst id={`rolle-${arbeidsflate}`} />
+                <Tekst id={`rolle-${arbeidsflate}` as LangKey} />
             </Heading>
             <LenkeMedSporing
                 href={href}

--- a/src/komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/innlogget/MobilInnloggetForsideLenke.tsx
+++ b/src/komponenter/header/header-regular/mobil/meny/innhold/hovedmeny/innlogget/MobilInnloggetForsideLenke.tsx
@@ -22,15 +22,15 @@ export const MobilInnloggetForsideLenke = () => {
     const lenkeProps =
         arbeidsflate === MenuValue.PRIVATPERSON
             ? {
-                  tekstIdHeader: 'min-side',
-                  tekstIdLenke: 'til-dittnav-forside',
+                  tekstIdHeader: 'min-side' as const,
+                  tekstIdLenke: 'til-dittnav-forside' as const,
                   href: MIN_SIDE_URL,
                   analyticsAction: 'dittnav',
               }
             : arbeidsflate === MenuValue.ARBEIDSGIVER
             ? {
-                  tekstIdHeader: 'min-side-arbeidsgiver',
-                  tekstIdLenke: 'ga-til-min-side-arbeidsgiver',
+                  tekstIdHeader: 'min-side-arbeidsgiver' as const,
+                  tekstIdLenke: 'ga-til-min-side-arbeidsgiver' as const,
                   href: MINSIDE_ARBEIDSGIVER_URL + valgtbedrift(),
                   analyticsAction: 'minside-arbeidsgiver',
               }

--- a/src/tekster/finn-tekst.test.tsx
+++ b/src/tekster/finn-tekst.test.tsx
@@ -1,5 +1,6 @@
 import { Locale } from '../store/reducers/language-duck';
 import { finnTekst } from './finn-tekst';
+import { LangKey } from './ledetekster';
 
 describe('finnTekst', () => {
     it('Skal finne riktig tekst (Søk/norsk)', () => {
@@ -18,7 +19,7 @@ describe('finnTekst', () => {
     });
 
     it('Skal returnere id hvis tekst ikke finnes)', () => {
-        const tekst = finnTekst('mikke-mus', Locale.BOKMAL);
+        const tekst = finnTekst('mikke-mus' as LangKey, Locale.BOKMAL);
         expect(tekst === 'mikke-mus');
     });
 });

--- a/src/tekster/finn-tekst.tsx
+++ b/src/tekster/finn-tekst.tsx
@@ -17,12 +17,10 @@ export function finnTekst(id: LangKey, language: Locale, payload?: string): stri
         case Locale.ENGELSK:
         case Locale.UKRAINSK:
         case Locale.RUSSISK:
-            id += '-en';
-            ledetekst = ledetekster[id as LangKey];
+            ledetekst = ledetekster[`${id}-en`];
             break;
         case Locale.SAMISK:
-            id += '-se';
-            ledetekst = ledetekster[id as LangKey];
+            ledetekst = ledetekster[`${id}-se`];
             break;
     }
 
@@ -46,7 +44,7 @@ export function finnTekst(id: LangKey, language: Locale, payload?: string): stri
 
 type Props = {
     id: LangKey;
-}
+};
 
 const Tekst = ({ id }: Props) => {
     const { language } = useSelector((state: AppState) => state.language);

--- a/src/tekster/finn-tekst.tsx
+++ b/src/tekster/finn-tekst.tsx
@@ -44,7 +44,7 @@ export function finnTekst(id: LangKey, language: Locale, payload?: string): stri
     return ledetekst(payload);
 }
 
-interface Props {
+type Props = {
     id: LangKey;
 }
 

--- a/src/tekster/finn-tekst.tsx
+++ b/src/tekster/finn-tekst.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { ledetekster, stringOrFunction } from './ledetekster';
+import { LangKey, ledetekster, stringOrFunction } from './ledetekster';
 import { AppState } from 'store/reducers';
 import { useSelector } from 'react-redux';
 import { Locale } from 'store/reducers/language-duck';
 
-export function finnTekst(id: string, language: Locale, payload?: string): string {
+export function finnTekst(id: LangKey, language: Locale, payload?: string): string {
     // Correct language
     let ledetekst: stringOrFunction;
     switch (language) {
@@ -18,11 +18,11 @@ export function finnTekst(id: string, language: Locale, payload?: string): strin
         case Locale.UKRAINSK:
         case Locale.RUSSISK:
             id += '-en';
-            ledetekst = ledetekster[id];
+            ledetekst = ledetekster[id as LangKey];
             break;
         case Locale.SAMISK:
             id += '-se';
-            ledetekst = ledetekster[id];
+            ledetekst = ledetekster[id as LangKey];
             break;
     }
 
@@ -45,7 +45,7 @@ export function finnTekst(id: string, language: Locale, payload?: string): strin
 }
 
 interface Props {
-    id: string;
+    id: LangKey;
 }
 
 const Tekst = ({ id }: Props) => {

--- a/src/tekster/ledetekster.ts
+++ b/src/tekster/ledetekster.ts
@@ -1,6 +1,8 @@
 export type stringOrFunction = string | ((input: string) => string);
+ 
+export type LangKey = keyof typeof ledetekster;
 
-export const ledetekster: { [key: string]: stringOrFunction } = {
+export const ledetekster = {
     'footer-arbeids-og-veldferdsetaten': 'Arbeids- og velferdsetaten',
     'footer-arbeids-og-veldferdsetaten-en': 'Arbeids- og velferdsetaten',
     'footer-arbeids-og-veldferdsetaten-se': 'Arbeids- og velferdsetaten',
@@ -327,4 +329,4 @@ export const ledetekster: { [key: string]: stringOrFunction } = {
     arkiver: 'Arkiver',
     'arkiver-en': 'Archive',
     'arkiver-se': 'Arkiver',
-};
+} as const;

--- a/src/tekster/ledetekster.ts
+++ b/src/tekster/ledetekster.ts
@@ -1,9 +1,9 @@
 export type stringOrFunction = string | ((input: string) => string);
- 
+
 type AllKeys = keyof typeof ledetekster;
 
 // Remove the language suffixes
-export type LangKey = Exclude<AllKeys, `${string}-en` | `${string}-se`>
+export type LangKey = Exclude<AllKeys, `${string}-en` | `${string}-se`>;
 
 export const ledetekster = {
     'footer-arbeids-og-veldferdsetaten': 'Arbeids- og velferdsetaten',
@@ -321,8 +321,8 @@ export const ledetekster = {
     'beskjed.maskert.tekst-en': 'You have a message, please log in with a higher security level to read the message.',
     'beskjed.maskert.tekst-se': 'Du har fått en melding, logg inn med høyere sikkerhetsnivå for å se meldingen.',
     'varslet-epost-og-sms': 'Varslet på e-post og SMS',
-    'varslet-epost-og-en': 'Notified by e-mail and SMS',
-    'varslet-epost-og-se': 'Varslet på e-post og SMS',
+    'varslet-epost-og-sms-en': 'Notified by e-mail and SMS',
+    'varslet-epost-og-sms-se': 'Varslet på e-post og SMS',
     'varslet-epost': 'Varslet på e-post',
     'varslet-epost-en': 'Notified by e-mail',
     'varslet-epost-se': 'Varslet på e-post',

--- a/src/tekster/ledetekster.ts
+++ b/src/tekster/ledetekster.ts
@@ -1,6 +1,9 @@
 export type stringOrFunction = string | ((input: string) => string);
  
-export type LangKey = keyof typeof ledetekster;
+type AllKeys = keyof typeof ledetekster;
+
+// Remove the language suffixes
+export type LangKey = Exclude<AllKeys, `${string}-en` | `${string}-se`>
 
 export const ledetekster = {
     'footer-arbeids-og-veldferdsetaten': 'Arbeids- og velferdsetaten',


### PR DESCRIPTION
## Bedre typesafety på tekstinnhold

Hente ut nøkkelene i tekst objektet og bruke det som parameter når tekst skal renderes. Utility typen viser nøklene uavhengig av språk.

![image](https://github.com/navikt/nav-dekoratoren/assets/135981901/bd383e11-e401-4bfe-af3b-ce802841ac45)

Hvis du føler at du vet mere enn typescript, så er det bare å caste stringen til en LangKey. Bedre at den er litt streng enn motsatt.

## Testing

Har bare endret typene, så ingen funksjonell endringer. Funker som normalt.