### PR TITLE
Fjerner egen styling på spinner og bruker korrekt size prop

### DIFF
--- a/src/komponenter/header/header-regular/common/spinner/Spinner.module.scss
+++ b/src/komponenter/header/header-regular/common/spinner/Spinner.module.scss
@@ -1,12 +1,5 @@
 .spinnerContainer {
     width: 100%;
     text-align: center;
-    padding: 1rem;
-}
-
-.dekoratorSpinner {
-    all: unset;
-    width: 64px;
-    height: 64px;
-    margin-top: 1rem;
+    padding: 2rem 1rem 1rem 1rem;
 }

--- a/src/komponenter/header/header-regular/common/spinner/Spinner.tsx
+++ b/src/komponenter/header/header-regular/common/spinner/Spinner.tsx
@@ -17,7 +17,7 @@ const Spinner = ({ tekstId }: Props) => {
                     <Tekst id={tekstId} />
                 </BodyShort>
             )}
-            <Loader className={style.dekoratorSpinner} id={id} />
+            <Loader size={'3xlarge'} id={id} />
         </div>
     );
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Fikser feil i spinner forårsaket av egen styling. Fjerner stylingen og bruker korrekt size props fra DS istedet.
- Legger på litt mer balansert padding i topp.

## Testing
Testet i dev
![Screenshot 2023-06-15 at 09 26 58](https://github.com/navikt/nav-dekoratoren/assets/1443997/fa75013c-1fb9-4549-be04-c36522de46e3)
