### PR TITLE
Proof of concept of typehints

### DIFF
--- a/src/taxonomy/index.ts
+++ b/src/taxonomy/index.ts
@@ -1,0 +1,39 @@
+type MakeExtendable<T> = Partial<T> & Record<string, unknown>;
+
+type AccordianÅpnet = {
+    name: 'accordian åpnet';
+    standard: true;
+    properties: MakeExtendable<{
+        tekst: string;
+    }>;
+};
+
+type AccordianLukket = {
+    name: 'accordian lukket';
+    standard: true;
+    properties: MakeExtendable<{
+        tekst: string;
+    }>;
+};
+
+type Tilbakemelding = {
+    name: 'tilbakemelding';
+    properties: MakeExtendable<{
+        kilde: string;
+        svar: string;
+    }>;
+};
+
+export type AmplitudeEvent = AccordianÅpnet | AccordianLukket | Tilbakemelding;
+
+function testLogEvent<TName extends AmplitudeEvent['name']>(
+    eventName: TName,
+    eventData: Extract<AmplitudeEvent, { name: TName }>['properties'],
+    origin = 'dekoratoren'
+) {
+    console.log('Logging this event');
+}
+
+testLogEvent('tilbakemelding', {
+    kilde: 'footer',
+});

--- a/src/taxonomy/index.ts
+++ b/src/taxonomy/index.ts
@@ -26,9 +26,14 @@ type Tilbakemelding = {
 
 export type AmplitudeEvent = AccordianÅpnet | AccordianLukket | Tilbakemelding;
 
-function testLogEvent<TName extends AmplitudeEvent['name']>(
+// eslint-disable-next-line @typescript-eslint/ban-types
+type AutocompleteString = string & {};
+type EventName = AmplitudeEvent['name'];
+type AutocompleteEventName = EventName | AutocompleteString;
+
+function testLogEvent<TName extends AutocompleteEventName>(
     eventName: TName,
-    eventData: Extract<AmplitudeEvent, { name: TName }>['properties'],
+    eventData: TName extends EventName ? Extract<AmplitudeEvent, { name: TName }>['properties'] : any,
     origin = 'dekoratoren'
 ) {
     console.log('Logging this event');
@@ -36,4 +41,12 @@ function testLogEvent<TName extends AmplitudeEvent['name']>(
 
 testLogEvent('tilbakemelding', {
     kilde: 'footer',
+    var: 'yes',
+    extraFelt: 'ok',
+});
+
+testLogEvent('customEvent', {
+    kilde: 'footer',
+    var: 'yes',
+    extraFelt: 'ok',
 });


### PR DESCRIPTION
## Proof of concept for typehints

Proof of concept for typehints på taxonomy. Med denne implementasjonen bevarer man også samme syntaksen, så det brekker ingenting. Den vil heller ikke skrike på deg hvis du legger til ekstra felt eller custom events, kun gi deg typehints.

Ikke ment for å merges inn nå, men samle tilbakemeldinger.

## Med en definert event
<img width="709" alt="image" src="https://github.com/navikt/nav-dekoratoren/assets/135981901/09e44d99-db2c-4178-b67a-928740f3b9bb">

## Legge til ekstra felt
<img width="453" alt="image" src="https://github.com/navikt/nav-dekoratoren/assets/135981901/b7799152-2bd5-413f-9f22-5b53da971ba3">


## Dette trenger jeg å få et ekstra blikk på

- Hvordan dette burde integreres med Tobias sitt taxonomy prosjekt

## Todo

- [ ] Gjøre det mulig og enkelt å injecte custom events for de som bruker dekoratøren i sine prosjekter. Tar gjerne innspill her. Tenkte typ declaration merging?
