### PR TITLE
Setter linjehøyde 1.5 på li-elementer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ _Merk:_ Dekoratøren på disse ingressene skal være relativt stabil både funks
 Team nav.no:
 
 -   http://nav-dekoratoren-beta.personbruker (service host)
--   https://dekoratoren-beta.dev.nav.no/
+-   https://dekoratoren-beta.intern.dev.nav.no/
 
 Team min side:
 
 -   http://nav-dekoratoren-beta-tms.personbruker (service host)
--   https://dekoratoren-beta-tms.dev.nav.no/
+-   https://dekoratoren-beta-tms.intern.dev.nav.no/
 
 _Merk:_ Dekoratøren på disse ingressene er ment for testing av pågående utvikling i team personbruker, og bør ikke konsumeres av andre applikasjoner ettersom de kan være ustabile i lengre perioder.
 

--- a/src/komponenter/common/lenke-med-sporing/LenkeMedSporing.module.scss
+++ b/src/komponenter/common/lenke-med-sporing/LenkeMedSporing.module.scss
@@ -4,12 +4,12 @@
     display: flex;
     flex-direction: row;
     align-items: flex-start;
-    padding: 0.5rem 0;
+    padding: 0.375rem 0;
     text-decoration: none;
     cursor: pointer;
 
     @media #{sv.$screen-desktop-small-down} {
-        padding: 0.375rem 0;
+        padding: 0.25rem 0;
     }
 
     &:hover {

--- a/src/komponenter/footer/feedback/Feedback.module.scss
+++ b/src/komponenter/footer/feedback/Feedback.module.scss
@@ -14,6 +14,10 @@
     @media #{sv.$screen-desktop-large-up} {
         padding: 1rem 0;
     }
+
+    label {
+        line-height: 1.5;
+    }
 }
 
 .feedbackContent {

--- a/src/komponenter/footer/footer-regular/footer-topp/FooterTopp.module.scss
+++ b/src/komponenter/footer/footer-regular/footer-topp/FooterTopp.module.scss
@@ -42,6 +42,9 @@
     ul {
         margin: 0;
     }
+    li {
+        line-height: 1.5;
+    }
 
     @media #{sv.$screen-desktop} {
         padding-top: var(--a-spacing-11, 2.75rem);

--- a/src/komponenter/header/Header.scss
+++ b/src/komponenter/header/Header.scss
@@ -1,5 +1,11 @@
 @use 'src/styling-variabler' as sv;
 
+header {
+    li {
+        line-height: 1.5;
+    }
+}
+
 .decorator-utils-container {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Setter linjehøyde 1.5 på li-elementer og "Fant du det du lette etter"
- Kniper litt på padding i toppmenyen
- Oppdatert README.md med korrekte interne url-er

## Testing
Har testet selv lokalt og i beta-dev

## Skjermbilde
FØR:
![Skjermbilde 2023-07-06 kl  14 24 50](https://github.com/navikt/nav-dekoratoren/assets/35491554/c6c88805-5054-40df-bf79-e754c09b0ce2)

ETTER - Litt mindre luft mellom elemeneter, litt mer luft mellom linjer innenfor elementene:
![Skjermbilde 2023-07-06 kl  14 24 50](https://github.com/navikt/nav-dekoratoren/assets/35491554/e4a8ed4e-57d9-4cc3-bfc6-1b33c01170db)
