### PR TITLE
Fikser offset-plassering av chatbotikon

### DIFF
--- a/src/komponenter/footer/chatbot/ChatbotWrapper.module.scss
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.module.scss
@@ -9,7 +9,7 @@ $chatbotCircleColor: var(--a-blue-800);
     margin-right: ($openButtonAvatarSizeNumber / 3) * 1px;
     margin-bottom: ($openButtonAvatarSizeNumber / 6) * 1px;
     position: fixed;
-    bottom: 8px;
+    bottom: 20px;
     right: 8px;
     z-index: 998;
     border: 0;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Flytter ikon oppover for å offsette justeringer som har blitt gjort med høyden på wrapper.

## Testing
Testet i dev