### PR TITLE
Justerer layout for lenker i SimpleFooter

### DIFF
--- a/src/komponenter/footer/common/del-skjerm-lenke/DelSkjermLenke.module.scss
+++ b/src/komponenter/footer/common/del-skjerm-lenke/DelSkjermLenke.module.scss
@@ -2,7 +2,6 @@
     text-decoration: underline;
     text-decoration-thickness: 0.0625em;
     text-underline-offset: 0.15em;
-    cursor: pointer;
 
     svg {
         margin-left: 0.5rem;

--- a/src/komponenter/footer/common/del-skjerm-lenke/DelSkjermLenke.module.scss
+++ b/src/komponenter/footer/common/del-skjerm-lenke/DelSkjermLenke.module.scss
@@ -1,4 +1,9 @@
 .delSkjermLenke {
+    text-decoration: underline;
+    text-decoration-thickness: 0.0625em;
+    text-underline-offset: 0.15em;
+    cursor: pointer;
+
     svg {
         margin-left: 0.5rem;
     }

--- a/src/komponenter/footer/common/del-skjerm-lenke/DelSkjermLenke.tsx
+++ b/src/komponenter/footer/common/del-skjerm-lenke/DelSkjermLenke.tsx
@@ -31,7 +31,7 @@ export const DelSkjermLenke = () => {
 
     return (
         <>
-            <Link onClick={openModal} className={classNames(style.delSkjermLenke, 'globalLenkeFooter')} href="#">
+            <Link onClick={openModal} className={classNames(style.delSkjermLenke)} href="#">
                 <Tekst id="footer-del-skjerm" />
                 <Monitor title="monitor-ikon" titleId="footer-monitor-icon" aria-hidden />
             </Link>

--- a/src/komponenter/footer/footer-simple/FooterSimple.module.scss
+++ b/src/komponenter/footer/footer-simple/FooterSimple.module.scss
@@ -1,7 +1,7 @@
 @use 'src/styling-variabler' as sv;
 
 .container {
-    min-height: 5.5rem;
+    min-height: 4rem;
     display: flex;
     flex-direction: row;
     border-top: 2px solid #0067c5;
@@ -23,6 +23,7 @@
 
     @media #{sv.$screen-mobile} {
         padding-bottom: 2.5rem;
+        flex-direction: column;
     }
 
     @media #{sv.$screen-desktop} {
@@ -33,9 +34,9 @@
 }
 
 .personvernLenker {
-    width: 100%;
     @media #{sv.$screen-mobile} {
-        margin: 0.5rem 0;
+        width: 100%;
+        margin: 0 0 0.5rem;
         li {
             padding: 0.375rem 0;
         }
@@ -44,7 +45,7 @@
         margin: 0;
         display: flex;
         flex-wrap: wrap;
-        max-width: calc(100% - 12rem);
+        max-width: fit-content;
 
         li {
             display: inline-flex;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Lik understrek som på andre lenker i skjermdelingslenke
- Lavere høyde på footer på desktop
- Skjermdelingslenke brekkes ikke lenger i to

## Testing
Testes i dev beta.
