### PR TITLE
skiplink som link + aria-labelled-by for å unngå dobbelt opplesning i SR

### DIFF
--- a/src/komponenter/header/common/skiplinks/Skiplink.tsx
+++ b/src/komponenter/header/common/skiplinks/Skiplink.tsx
@@ -1,14 +1,23 @@
-import React, { useEffect, useState } from 'react';
-import { logAmplitudeEvent } from 'utils/analytics/amplitude';
+import React, {useEffect, useState} from 'react';
+import { LenkeMedSporing } from 'komponenter/common/lenke-med-sporing/LenkeMedSporing';
+import { AnalyticsEventArgs, AnalyticsCategory } from 'utils/analytics/analytics';
 import Tekst from 'tekster/finn-tekst';
 
 import style from './Skiplink.module.scss';
 
 const mainContentId = 'maincontent';
+const mainContentHref = `#${mainContentId}`;
+const skiplinkTextId = 'skiplink-text';
 
 const Skiplink = () => {
     const [hasMainContent, setHasMainContent] = useState(false);
     const linkTextId = 'skiplinks-ga-til-hovedinnhold';
+    const anlyticsProps:AnalyticsEventArgs = {
+        category: AnalyticsCategory.Header,
+        eventName: 'skiplinks',
+        action: linkTextId,
+        destination: mainContentHref,
+    }
 
     useEffect(() => {
         const mainContentElement = document.getElementById(mainContentId);
@@ -16,16 +25,16 @@ const Skiplink = () => {
     }, []);
 
     return hasMainContent ? (
-        <nav aria-label="Hopp til innhold">
-            <button
+        <nav aria-labelledby={skiplinkTextId}>
+            <LenkeMedSporing
+                href={mainContentHref}
                 className={style.skiplink}
-                onClick={() => {
-                    logAmplitudeEvent('skiplinks', { kilde: 'header', fritekst: linkTextId });
-                    document.getElementById(mainContentId)?.focus();
-                }}
+                analyticsEventArgs={anlyticsProps}
             >
-                <Tekst id={linkTextId} />
-            </button>
+                <span id={skiplinkTextId}>
+                    <Tekst id={linkTextId} />
+                </span>
+            </LenkeMedSporing>
         </nav>
     ) : null;
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort

-  LenkeMedSporing istedenfor knapp
-  aria-labelled-by for å unngå dobbelt opplesning i SR

## Testing

Har testet selv lokalt og i dev2

## Ønsker tilbakemelding på
Bytter fra å hoppe til element med javascript til href= '#maincontent' (som er mer standard måte å håndtere dette på).
Er dette greit?
