### PR TITLE
Use cookies instead of localStorage to check screensharing user state

### DIFF
--- a/src/komponenter/header/Header.tsx
+++ b/src/komponenter/header/Header.tsx
@@ -97,7 +97,9 @@ export const Header = () => {
         }
     }, [menypunkt]);
 
-    useLoadIfActiveSession();
+    useLoadIfActiveSession({
+        userState: cookies['psCurrentState']
+    });
 
     // Handle enforced login
     useEffect(() => {

--- a/src/utils/hooks/useScreenSharing.ts
+++ b/src/utils/hooks/useScreenSharing.ts
@@ -47,10 +47,8 @@ export function useScreenSharing({ enabled }: UseScreenSharingOptions): UseScree
 
 export function useLoadIfActiveSession({ userState }: { userState: string | undefined }) {
     useEffect(() => {
-        if (userState) {
-            if (userState && userState !== 'Ready') {
-                loadExternalScript(vendorScripts.skjermdeling);
-            }
+        if (userState && userState !== 'Ready') {
+            loadExternalScript(vendorScripts.skjermdeling);
         }
     }, [userState]);
 }

--- a/src/utils/hooks/useScreenSharing.ts
+++ b/src/utils/hooks/useScreenSharing.ts
@@ -45,13 +45,12 @@ export function useScreenSharing({ enabled }: UseScreenSharingOptions): UseScree
     };
 }
 
-export function useLoadIfActiveSession() {
+export function useLoadIfActiveSession({ userState }: { userState: string | undefined }) {
     useEffect(() => {
-        const userState = localStorage.getItem(`vngage_${VNGAGE_ID.toLowerCase()}`);
-        const parsedUserState = userState ? (JSON.parse(userState) as VngageUserState) : undefined;
-
-        if (parsedUserState && parsedUserState.user.state !== 'Ready') {
-            loadExternalScript(vendorScripts.skjermdeling);
+        if (userState) {
+            if (userState && userState !== 'Ready') {
+                loadExternalScript(vendorScripts.skjermdeling);
+            }
         }
-    }, []);
+    }, [userState]);
 }

--- a/src/utils/hooks/useScreenSharing.ts
+++ b/src/utils/hooks/useScreenSharing.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { VNGAGE_ID, VngageUserState, vendorScripts } from 'komponenter/header/vendorScripts';
+import { vendorScripts } from 'komponenter/header/vendorScripts';
 import { loadExternalScript } from 'utils/external-scripts';
 
 type UseScreenSharingOptions = {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Eks:

-   Endrer til å bruke cookies instedenfor localstorage, slik at det funker på tvers av subdomains.

## Testing

Eks: Litt vanskelig å få testet lokalt, men sjekket at cookies lastes og sett at cookien scopes på tvers av subdomains.

