### PR TITLE
Korrekt bruk av role for Driftsmeldinger

### DIFF
--- a/src/komponenter/header/common/driftsmeldinger/Driftsmeldinger.tsx
+++ b/src/komponenter/header/common/driftsmeldinger/Driftsmeldinger.tsx
@@ -94,10 +94,11 @@ export const Driftsmeldinger = () => {
                             category: AnalyticsCategory.Header,
                             action: 'driftsmeldinger',
                         }}
-                        {...srRoleProp}
                     >
                         <span className={style.messageIcon}>{melding.type && <Icon type={melding.type} />}</span>
-                        <BodyLong>
+                        <BodyLong
+                            {...srRoleProp}
+                        >
                             {melding.heading}
                         </BodyLong>
                     </LenkeMedSporing>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Flytter role=alert/status fra lenke til tekst i lenken (rollene kan bare knyttes til faktisk innhold)

## Testing

Har testet selv lokalt og dev 
Morten Tollefsen har godkjent

