### PR TITLE
Adds filter change to the chatbot

### DIFF
--- a/src/csp.ts
+++ b/src/csp.ts
@@ -14,7 +14,7 @@ const vimeoCdn = '*.vimeocdn.com'; // used for video preview images
 const hotjarCom = '*.hotjar.com';
 const hotjarIo = '*.hotjar.io';
 const taskAnalytics = '*.taskanalytics.com';
-const googleStorage = 'https://storage.googleapis.com';
+const googleStorage = 'storage.googleapis.com';
 
 const styleSrc = [
     navNo,

--- a/src/csp.ts
+++ b/src/csp.ts
@@ -14,6 +14,7 @@ const vimeoCdn = '*.vimeocdn.com'; // used for video preview images
 const hotjarCom = '*.hotjar.com';
 const hotjarIo = '*.hotjar.io';
 const taskAnalytics = '*.taskanalytics.com';
+const googleStorage = 'https://storage.googleapis.com';
 
 const styleSrc = [
     navNo,
@@ -51,7 +52,7 @@ const directives: Partial<CSPDirectives> = {
         cdnNavNo,
         DATA, // ds-css
     ],
-    'img-src': [navNo, vergicScreenSharing, vimeoCdn, hotjarCom, vergicDotCom],
+    'img-src': [navNo, vergicScreenSharing, vimeoCdn, hotjarCom, vergicDotCom, googleStorage],
     'frame-src': [hotjarCom, vimeoPlayer, qbrick],
     'connect-src': [navNo, boostChatbot, vergicScreenSharing, hotjarCom, hotjarIo, taskAnalytics],
 };

--- a/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
@@ -8,8 +8,6 @@ import { FridaIcon } from './FridaIcon';
 import { BoostConfig, BoostObject } from './boost-config';
 
 import style from './ChatbotWrapper.module.scss';
-import { MenuValue } from 'utils/meny-storage-utils';
-import { Locale } from 'store/reducers/language-duck';
 
 const stateSelector = (state: AppState) => ({
     chatbotParamEnabled: state.environment.PARAMS.CHATBOT,
@@ -17,8 +15,6 @@ const stateSelector = (state: AppState) => ({
     featureToggles: state.featureToggles,
     context: state.arbeidsflate.status,
     env: state.environment.ENV,
-    language: state.language.language,
-    arbeidsflate: state.arbeidsflate.status,
 });
 
 const conversationCookieName = 'nav-chatbot%3Aconversation';
@@ -27,7 +23,7 @@ const boostApiUrlBaseTest = 'navtest';
 const boostApiUrlBaseProduction = 'nav';
 
 export const ChatbotWrapper = () => {
-    const { chatbotParamEnabled, chatbotParamVisible, env, language, arbeidsflate } = useSelector(stateSelector);
+    const { chatbotParamEnabled, chatbotParamVisible, env } = useSelector(stateSelector);
     const [cookies, setCookie, removeCookie] = useCookies([conversationCookieName]);
 
     // Do not mount chatbot on initial render. Prevents hydration errors
@@ -55,13 +51,6 @@ export const ChatbotWrapper = () => {
         if (typeof window === 'undefined' || typeof window.boostInit === 'undefined' || boost) {
             return;
         }
-
-        // let preferredFilter;
-        // if (arbeidsflate === MenuValue.ARBEIDSGIVER) {
-        //     preferredFilter = 'arbeidsgiver';
-        // } else {
-        //     preferredFilter = language === Locale.NYNORSK ? 'nynorsk' : 'bokmal';
-        // }
 
         const options: BoostConfig = {
             chatPanel: {

--- a/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
@@ -56,12 +56,12 @@ export const ChatbotWrapper = () => {
             return;
         }
 
-        let preferredFilter;
-        if (arbeidsflate === MenuValue.ARBEIDSGIVER) {
-            preferredFilter = 'arbeidsgiver';
-        } else {
-            preferredFilter = language === Locale.NYNORSK ? 'nynorsk' : 'bokmal';
-        }
+        // let preferredFilter;
+        // if (arbeidsflate === MenuValue.ARBEIDSGIVER) {
+        //     preferredFilter = 'arbeidsgiver';
+        // } else {
+        //     preferredFilter = language === Locale.NYNORSK ? 'nynorsk' : 'bokmal';
+        // }
 
         const options: BoostConfig = {
             chatPanel: {
@@ -73,11 +73,6 @@ export const ChatbotWrapper = () => {
                 styling: {
                     buttons: {
                         multiline: true,
-                    },
-                },
-                header: {
-                    filters: {
-                        filterValues: preferredFilter,
                     },
                 },
             },

--- a/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
@@ -56,12 +56,12 @@ export const ChatbotWrapper = () => {
             return;
         }
 
-        const preferredFilter =
-            arbeidsflate === MenuValue.ARBEIDSGIVER
-                ? 'arbeidsgiver'
-                : language === Locale.NYNORSK
-                ? 'nynorsk'
-                : 'bokmal';
+        let preferredFilter;
+        if (arbeidsflate === MenuValue.ARBEIDSGIVER) {
+            preferredFilter = 'arbeidsgiver';
+        } else {
+            preferredFilter = language === Locale.NYNORSK ? 'nynorsk' : 'bokmal';
+        }
 
         const options: BoostConfig = {
             chatPanel: {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Legger til mulighet å endre chatbot filtre fra boost. Det vil da si at AI ekspertene som jobber med intentene i Boost kan la brukeren endre filtre ved knapper i stedet for nedtrekksmeny, slik det er nå. Dette er hovedsakelig for å enkelt overføre personer til arbeidsgiver chat, hvis de åpnet den i privatperson context.
Satt også opp automatisk valg av arbeidsgiver hvis personen er på en arbeidsgiver-side når chatbotten starter. Og det samme for nynorsk, hvis de er på en nynorsk side. (Det finnes per i dag ingen nynorsk arbeidsgiver filter i boost, så det fungerer bare for privatperson).

## Testing

Testet det både lokalt, og deployet til dev og testet der.

## Dette trenger jeg å få et ekstra blikk på

Jeg gjorde noen ekstra tester og fant ut at det automatisk filteret ikke fungerte helt perfekt i alle tilfeller. Spesifikt så settes det bare når chatbotten instansieres, og vil dermed alltid default til det filteret hver gang en ny chat startes, uavhengig av hva brukeren har valgt på chatten før eller hvilken side de er på når den nye chatten startes. Dette hadde jeg antatt var ønskelig, men med litt videre testing fant jeg noen problemer med at nav.no siden er automatisk privatperson - bokmål, som gjorde funksjonaliteten veldig lite brukbar og ikke særlig intuitiv.

## Skjermbilde hvis relevant
