### PR TITLE
Fiks valideringsfeil crossorigin

### DIFF
--- a/src/head.ts
+++ b/src/head.ts
@@ -14,7 +14,7 @@ export const fontAttribs = {
     href: 'https://cdn.nav.no/aksel/fonts/SourceSans3-normal.woff2',
     as: 'font',
     type: 'font/woff2',
-    crossorigin: 'true',
+    crossorigin: 'anonymous',
 };
 
 type Tag = {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Setter crossorigin til `anonymous`. [Crossorigin kan ikke være "true".](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#anonymous:~:text=These%20attributes%20are,as%20anonymous.)

Oppdaget ved å bruke [W3C sin validator](https://validator.w3.org/nu/?showsource=yes&doc=https%3A%2F%2Fwww.nav.no%2Fdekoratoren).

## Testing

Testet i dev
