### PR TITLE
Norsk oversettelse i språkvelger

### DIFF
--- a/src/komponenter/header/common/sprakvelger/SprakVelger.tsx
+++ b/src/komponenter/header/common/sprakvelger/SprakVelger.tsx
@@ -124,10 +124,10 @@ const labels: { [key: string]: string } = {
     nb: 'Norsk (bokmål)',
     nn: 'Norsk (nynorsk)',
     en: 'English',
-    se: 'Sámegiel',
-    pl: 'Polski',
-    uk: 'Українська',
-    ru: 'Русский',
+    se: 'Sámegiel (samisk)',
+    pl: 'Polski (polsk)',
+    uk: 'Українська (ukrainsk)',
+    ru: 'Русский (russisk)',
 };
 
 // Utils


### PR DESCRIPTION
-   Legger til norsk oversettelse i språkvelger for ukrainsk, russisk, polsk og samisk.

([Tilsvarende PR i decorator-next](https://github.com/navikt/decorator-next/pull/174))

## Testing

Har testet selv i dev

## Skjermbilde hvis relevant

![image](https://github.com/navikt/nav-dekoratoren/assets/71373910/bd7202b9-beae-47ca-82f8-51102013d362)
