### PR TITLE
Triggers boost action from event when changing filter

### DIFF
--- a/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
@@ -134,7 +134,7 @@ export const ChatbotWrapper = () => {
         });
         boost.chatPanel.addEventListener('setFilterValue', function (ev: any) {
             boost.chatPanel.setFilterValues(ev.detail.filterValue);
-            boost.chatPanel.triggerAction(ev.detail.nextId);
+            if (ev.detail.nextId) boost.chatPanel.triggerAction(ev.detail.nextId);
         });
 
         if (bufferLoad) {

--- a/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
@@ -134,6 +134,7 @@ export const ChatbotWrapper = () => {
         });
         boost.chatPanel.addEventListener('setFilterValue', function (ev: any) {
             boost.chatPanel.setFilterValues(ev.detail.filterValue);
+            boost.chatPanel.triggerAction(ev.detail.nextId);
         });
 
         if (bufferLoad) {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Gjør det mulig for chatbot trenerne å triggre en intern chatbot action når de endrer chatbot filtre. Det er Boost selv som har bedt om endringene, og gitt kodesnutten. Det er ment å løse et problem der, pga. den nye endringen med å sette et default filter i boostInit så oppdateres ikke filterValue fra bare setFilterValues funksjonen med et klikk. Brukeren må trykke to ganger for at det skal ta effekt.

## Testing

Har ikke testet, endringene har ingen effekt i seg selv, men tilgjengeliggjør bare for chatbot trenerne til å gjøre mer

## Dette trenger jeg å få et ekstra blikk på

Skal ta kontakt med Boost for å få en mer utdypet forklarer for hva action de vil at vi skal skal kjøre faktisk gjør og hvorfor den er nødvendig. Skal også prøve å få en liste med alle mulige actions, mest for jeg er nysgjerrig, men også se på potensielle konsekvenser.

## Skjermbilde hvis relevant
