### PR TITLE
Bug-fix amplitude-logge innboks som beskjed og ikke oppgave

### DIFF
--- a/src/komponenter/header/header-regular/common/varsler/varsel-boks/VarselBoks.tsx
+++ b/src/komponenter/header/header-regular/common/varsler/varsel-boks/VarselBoks.tsx
@@ -62,7 +62,7 @@ const Beskjed = ({
             postInaktiver(VARSEL_API_URL, { eventId: eventId });
             dispatch(fjernLestVarsel(eventId));
         }
-        logAmplitudeEvent('navigere', { komponent: type.toLowerCase() == "beskjed" ? "varsel-beskjed" : "varsel-oppgave", kategori: "varselbjelle", destinasjon: href });
+        logAmplitudeEvent('navigere', { komponent: isOppgave ? "varsel-oppgave": "varsel-beskjed", kategori: "varselbjelle", destinasjon: href });
     };
 
     return isArkiverbar ? (


### PR DESCRIPTION
## Fikset på bug der klikk på varsel av type innboks ble logget som oppgave i amplitude

## Testing

Testet i dev-beta-tms at komponenten blir logget riktig.
