### PR TITLE
Fiks veileder skjult i modal

### DIFF
--- a/src/komponenter/footer/common/del-skjerm-modal/DelSkjermModal.module.scss
+++ b/src/komponenter/footer/common/del-skjerm-modal/DelSkjermModal.module.scss
@@ -4,6 +4,10 @@
     max-width: 35rem;
     overflow: visible;
     padding: 1rem;
+
+    :global(.navds-modal__body) {
+        overflow: visible;
+    }
 }
 
 .content {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Setter overflow visible på navds-modal__body 
- Bruker ikke mer tid på en penere løsning siden det ikke ser ut til å være et problem i decorator-next (som kommer ut snart)

## Testing

Har testet selv i dev

## Skjermbilde hvis relevant

<img width="671" alt="image" src="https://github.com/navikt/nav-dekoratoren/assets/71373910/c7bda047-9f3a-4821-b1f6-6ccf718f87e2">

