### PR TITLE
Clears chat conversation cookie on chat close

### DIFF
--- a/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
@@ -136,6 +136,9 @@ export const ChatbotWrapper = () => {
             boost.chatPanel.setFilterValues(ev.detail.filterValue);
             if (ev.detail.nextId) boost.chatPanel.triggerAction(ev.detail.nextId);
         });
+        boost.chatPanel.addEventListener('chatPanelClosed', () => {
+            removeCookie(conversationCookieName);
+        });
 
         if (bufferLoad) {
             setBufferLoad(false);


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Har lagt til en enkel listener som clearer cookie når samtalen med Frida er lukket. Før var dette håndtert med at Boost satt conversationId til null på close, så vi brukte conversationIdChanged listener til å utføre dette. Tydeligvis var dette en bug, som Boost nå har rettet opp i og vi må dermed slette cookien selv.

## Testing

Har testet lokalt, ingen stor endringer tenkte jeg. Og siden dere holder på med å teste den nye dekoratøren i dev tenkte jeg ikke det var nødvendig å forstyrre det arbeidet. Hvis dere ønsker så kan jeg fint teste det i dev og 😄.