### PR TITLE
Include domain settings on removeCookie

### DIFF
--- a/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
@@ -40,8 +40,14 @@ export const ChatbotWrapper = () => {
     const [scriptLoaded, setScriptLoaded] = useState<boolean>(false);
     const currentFeatureToggles = useSelector(stateSelector).featureToggles;
 
+    const isDevelopment: boolean = process.env.NODE_ENV === 'development';
     const isProduction = env === 'prod';
     const boostApiUrlBase = isProduction ? boostApiUrlBaseProduction : boostApiUrlBaseTest;
+
+    const cookieSettings = {
+        path: '/',
+        domain: isDevelopment ? 'localhost' : '.nav.no',
+    };
 
     const openBoostWindow = () => {
         if (typeof boost !== 'undefined') {
@@ -122,14 +128,14 @@ export const ChatbotWrapper = () => {
 
         boost.chatPanel.addEventListener('conversationIdChanged', (event: any) => {
             if (!event?.detail?.conversationId) {
-                removeCookie(conversationCookieName);
+                removeCookie(conversationCookieName, cookieSettings);
                 return;
             }
             const expirationDay = new Date();
             expirationDay.setHours(expirationDay.getHours() + 1);
             setCookie(conversationCookieName, event.detail.conversationId, {
                 expires: expirationDay,
-                domain: isProduction ? '.nav.no' : '.dev.nav.no',
+                ...cookieSettings,
             });
         });
         boost.chatPanel.addEventListener('setFilterValue', function (ev: any) {
@@ -137,7 +143,7 @@ export const ChatbotWrapper = () => {
             if (ev.detail.nextId) boost.chatPanel.triggerAction(ev.detail.nextId);
         });
         boost.chatPanel.addEventListener('chatPanelClosed', () => {
-            removeCookie(conversationCookieName);
+            removeCookie(conversationCookieName, cookieSettings);
         });
 
         if (bufferLoad) {

--- a/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
+++ b/src/komponenter/footer/chatbot/ChatbotWrapper.tsx
@@ -40,13 +40,13 @@ export const ChatbotWrapper = () => {
     const [scriptLoaded, setScriptLoaded] = useState<boolean>(false);
     const currentFeatureToggles = useSelector(stateSelector).featureToggles;
 
-    const isDevelopment: boolean = process.env.NODE_ENV === 'development';
+    const isLocal: boolean = env === 'localhost';
     const isProduction = env === 'prod';
     const boostApiUrlBase = isProduction ? boostApiUrlBaseProduction : boostApiUrlBaseTest;
 
     const cookieSettings = {
         path: '/',
-        domain: isDevelopment ? 'localhost' : '.nav.no',
+        domain: isLocal ? 'localhost' : '.nav.no',
     };
 
     const openBoostWindow = () => {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Eks:
Det er problemer med chatboten og cookies, removeCookie metoden som er inkludert i react-cookie sletter faktisk ikke cookien. Jeg mistenker at det er pga. domains i cookiene, så jeg tenker å prøve med det satt.

## Testing
Har testet det lokalt, men der klarte jeg heller ikke å gjenskape det originale problemet heller.

## Dette trenger jeg å få et ekstra blikk på
Det hadde vært fint hvis jeg kunne teste det i dev.nav.no først, men siden dere holder på med den nye dekoratøren forstår jeg det hvis dere ikke vil det.

## Skjermbilde hvis relevant
