### PR TITLE
Fjernet tekst for målgruppe hvis valgt språk er engelsk

### DIFF
--- a/src/komponenter/header/header-regular/common/sok/sok-innhold/SokResultater.tsx
+++ b/src/komponenter/header/header-regular/common/sok/sok-innhold/SokResultater.tsx
@@ -51,8 +51,8 @@ export const SokResultater = (props: Props) => {
                 <>
                     <Heading level="2" size="small" role="status">
                         {result.total} {finnTekst('sok-resultater', language)}
-                        {' for '} &laquo;{`${writtenInput}`}&raquo; {' for '}
-                        {finnTekst('sok-audience', language, audience)}
+                        {' for '} &laquo;{`${writtenInput}`}&raquo;
+                        {language !== 'en' && ` for ${finnTekst('sok-audience', language, audience)}`}
                     </Heading>
                     <Link className={'typo-element'} href={`${XP_BASE_URL}/sok?ord=${writtenInput}`}>
                         {`${finnTekst('sok-alle-treff', language)} `}


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Gjør en sjekk på om det er på engelsk side. Hvis ja, skal ikke "for privatperson" (målgruppe) vises i søkeresultatet.

## Testing

Har testet selv lokalt
